### PR TITLE
fix: add custom latest block structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	golang.org/x/crypto v0.32.0
 	golang.org/x/net v0.34.0
 	golang.org/x/sync v0.10.0
+	google.golang.org/grpc v1.70.0
 )
 
 require (
@@ -142,7 +143,6 @@ require (
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241202173237-19429a94021a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250122153221-138b5a5a4fd4 // indirect
-	google.golang.org/grpc v1.70.0 // indirect
 	google.golang.org/protobuf v1.36.4 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/seed/probes.go
+++ b/internal/seed/probes.go
@@ -95,22 +95,22 @@ func GRPCProbe(ctx context.Context, node Node) (Status, error) {
 	}, nil
 }
 
+type syncInfoResponse struct {
+	CatchingUp bool `json:"catching_up"`
+}
+
+type latestBlockResponse struct {
+	Block struct {
+		Header struct {
+			Height string `json:"height"`
+		} `json:"header"`
+	} `json:"block"`
+}
+
 // RESTProbe probes a REST Node.
 // It checks if the node is catching up querying the REST endpoint, queries the Node latest block and tries to set the
 // height globally.
 func RESTProbe(ctx context.Context, node Node) (Status, error) {
-	type syncInfoResponse struct {
-		CatchingUp bool `json:"catching_up"`
-	}
-
-	type latestBlockResponse struct {
-		Block struct {
-			Header struct {
-				Height string `json:"height"`
-			} `json:"header"`
-		} `json:"block"`
-	}
-
 	client := &http.Client{}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/syncing", node.Address), nil)

--- a/internal/seed/probes.go
+++ b/internal/seed/probes.go
@@ -99,11 +99,11 @@ func GRPCProbe(ctx context.Context, node Node) (Status, error) {
 // It checks if the node is catching up querying the REST endpoint, queries the Node latest block and tries to set the
 // height globally.
 func RESTProbe(ctx context.Context, node Node) (Status, error) {
-	type SyncInfo struct {
+	type syncInfoResponse struct {
 		CatchingUp bool `json:"catching_up"`
 	}
 
-	type LatestBlock struct {
+	type latestBlockResponse struct {
 		Block struct {
 			Header struct {
 				Height string `json:"height"`
@@ -133,7 +133,7 @@ func RESTProbe(ctx context.Context, node Node) (Status, error) {
 		return Status{}, fmt.Errorf("reading body from REST client response: %w", err)
 	}
 
-	var syncing SyncInfo
+	var syncing syncInfoResponse
 	if err := json.Unmarshal(body, &syncing); err != nil {
 		return Status{}, fmt.Errorf("unmarshaling body from REST client response: %w", err)
 	}
@@ -158,7 +158,7 @@ func RESTProbe(ctx context.Context, node Node) (Status, error) {
 		return Status{}, fmt.Errorf("reading body from REST client response: %w", err)
 	}
 
-	var latestBlock LatestBlock
+	var latestBlock latestBlockResponse
 	if err := json.Unmarshal(latestBlockBody, &latestBlock); err != nil {
 		return Status{}, fmt.Errorf("unmarshaling body from REST client response: %w", err)
 	}

--- a/internal/seed/probes.go
+++ b/internal/seed/probes.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/akash-network/rpc-proxy/internal/block"
@@ -105,7 +106,7 @@ func RESTProbe(ctx context.Context, node Node) (Status, error) {
 	type LatestBlock struct {
 		Block struct {
 			Header struct {
-				Height int64 `json:"header"`
+				Height string `json:"height"`
 			} `json:"header"`
 		} `json:"block"`
 	}
@@ -162,7 +163,12 @@ func RESTProbe(ctx context.Context, node Node) (Status, error) {
 		return Status{}, fmt.Errorf("unmarshaling body from REST client response: %w", err)
 	}
 
-	errLowBlock := block.GetInstance().SetLatestBlock(latestBlock.Block.Header.Height)
+	height, err := strconv.ParseInt(latestBlock.Block.Header.Height, 10, 64)
+	if err != nil {
+		return Status{}, fmt.Errorf("parsing block height: %w", err)
+	}
+
+	errLowBlock := block.GetInstance().SetLatestBlock(height)
 
 	return Status{
 		CatchingUp:    syncing.CatchingUp,

--- a/internal/seed/probes.go
+++ b/internal/seed/probes.go
@@ -5,14 +5,15 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"time"
+
 	"github.com/akash-network/rpc-proxy/internal/block"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"io"
-	"net/http"
-	"time"
 )
 
 // Probe is the interface that wraps the Probe method.
@@ -91,7 +92,6 @@ func GRPCProbe(ctx context.Context, node Node) (Status, error) {
 		Reachable:     true,
 		IsLatestBlock: errLowBlock == nil,
 	}, nil
-
 }
 
 // RESTProbe probes a REST Node.
@@ -100,6 +100,14 @@ func GRPCProbe(ctx context.Context, node Node) (Status, error) {
 func RESTProbe(ctx context.Context, node Node) (Status, error) {
 	type SyncInfo struct {
 		CatchingUp bool `json:"catching_up"`
+	}
+
+	type LatestBlock struct {
+		Block struct {
+			Header struct {
+				Height int64 `json:"header"`
+			} `json:"header"`
+		} `json:"block"`
 	}
 
 	client := &http.Client{}
@@ -149,7 +157,7 @@ func RESTProbe(ctx context.Context, node Node) (Status, error) {
 		return Status{}, fmt.Errorf("reading body from REST client response: %w", err)
 	}
 
-	var latestBlock cmtservice.GetLatestBlockResponse
+	var latestBlock LatestBlock
 	if err := json.Unmarshal(latestBlockBody, &latestBlock); err != nil {
 		return Status{}, fmt.Errorf("unmarshaling body from REST client response: %w", err)
 	}


### PR DESCRIPTION
This PR fixes a small issue with the REST nodes where unmarshaling was failing due to the exposed models on tendermint/cometbft having proto `uint64` fields as strings. With this fix we are only unmarshaling the fields that are required by the probes.