### PR TITLE
feat: implement latency based load balancer

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,9 +40,9 @@ func main() {
 		ChainID:             cfg.ChainID,
 	}
 	seeder := seed.New(seederCfg, log, rpcListener, restListener, grpcListener)
-	rpcProxyHandler := proxy.NewRPCProxy(rpcListener, cfg, log)
-	restProxyHandler := proxy.NewRestProxy(restListener, cfg, log)
-	grpcProxyHandler := proxy.NewGRPCProxy(grpcListener, cfg, log)
+	rpcProxyHandler := proxy.NewRPCProxy(rpcListener, cfg, log, proxy.NewLatencyBased(log))
+	restProxyHandler := proxy.NewRestProxy(restListener, cfg, log, proxy.NewLatencyBased(log))
+	grpcProxyHandler := proxy.NewGRPCProxy(grpcListener, cfg, log, proxy.NewLatencyBased(log))
 
 	ctx, proxyCtxCancel := context.WithCancel(context.Background())
 	defer proxyCtxCancel()

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	golang.org/x/crypto v0.32.0
 	golang.org/x/net v0.34.0
 	golang.org/x/sync v0.10.0
+	google.golang.org/grpc v1.70.0
 )
 
 require (
@@ -142,7 +143,6 @@ require (
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241202173237-19429a94021a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250122153221-138b5a5a4fd4 // indirect
-	google.golang.org/grpc v1.70.0 // indirect
 	google.golang.org/protobuf v1.36.4 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/avg/moving.go
+++ b/internal/avg/moving.go
@@ -1,3 +1,4 @@
+// Package avg provides a thread-safe moving average calculator for time.Duration values.
 package avg
 
 import (
@@ -5,24 +6,33 @@ import (
 	"time"
 )
 
+// Moving creates and returns a new MovingAverage with the specified window size.
+//
+// The window determines how many recent duration values will be considered
+// when calculating the moving average.
 func Moving(window int) *MovingAverage {
 	return &MovingAverage{
 		window: window,
 	}
 }
 
+// MovingAverage computes a moving average over a fixed-size sliding window
+// of time.Duration values. It is safe for concurrent use.
 type MovingAverage struct {
-	mu        sync.Mutex
-	window    int
-	durations []time.Duration
-	sum       time.Duration
-	avgMu     sync.RWMutex
-	lastAvg   time.Duration
+	mu        sync.Mutex      // protects durations and sum
+	window    int             // max number of durations to keep in the window
+	durations []time.Duration // recent durations within the window
+	sum       time.Duration   // sum of durations in the window
+
+	avgMu   sync.RWMutex  // protects access to lastAvg
+	lastAvg time.Duration // last computed average
 }
 
+// Reset clears all recorded durations and resets the moving average to zero.
 func (m *MovingAverage) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
 	m.sum = 0
 	m.avgMu.Lock()
 	m.lastAvg = 0
@@ -30,15 +40,25 @@ func (m *MovingAverage) Reset() {
 	m.durations = []time.Duration{}
 }
 
+// Last returns the most recently computed moving average without updating it.
+//
+// This method is safe to call concurrently.
 func (m *MovingAverage) Last() time.Duration {
 	m.avgMu.RLock()
 	defer m.avgMu.RUnlock()
 	return m.lastAvg
 }
 
+// Next adds a new duration value and updates the moving average.
+//
+// If the window is already full, the oldest duration is removed before
+// the new value is added. The method returns the updated moving average.
+//
+// This method is safe to call concurrently.
 func (m *MovingAverage) Next(d time.Duration) time.Duration {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
 	if len(m.durations) < m.window {
 		m.sum += d
 		m.durations = append(m.durations, d)
@@ -52,5 +72,6 @@ func (m *MovingAverage) Next(d time.Duration) time.Duration {
 	m.avgMu.Lock()
 	m.lastAvg = time.Duration(int(m.sum.Nanoseconds()) / len(m.durations))
 	m.avgMu.Unlock()
+
 	return m.lastAvg
 }

--- a/internal/avg/moving.go
+++ b/internal/avg/moving.go
@@ -19,13 +19,13 @@ func Moving(window int) *MovingAverage {
 // MovingAverage computes a moving average over a fixed-size sliding window
 // of time.Duration values. It is safe for concurrent use.
 type MovingAverage struct {
-	mu        sync.Mutex      // protects durations and sum
-	window    int             // max number of durations to keep in the window
-	durations []time.Duration // recent durations within the window
-	sum       time.Duration   // sum of durations in the window
+	mu        sync.Mutex
+	window    int
+	durations []time.Duration
+	sum       time.Duration
 
-	avgMu   sync.RWMutex  // protects access to lastAvg
-	lastAvg time.Duration // last computed average
+	avgMu   sync.RWMutex
+	lastAvg time.Duration
 }
 
 // Reset clears all recorded durations and resets the moving average to zero.

--- a/internal/proxy/balancer.go
+++ b/internal/proxy/balancer.go
@@ -1,39 +1,115 @@
 package proxy
 
 import (
+	"fmt"
 	"log/slog"
+	"math/rand"
 	"sync"
+	"time"
 )
 
 type LoadBalancer interface {
-	Next([]*Server) *Server
+	Update([]*Server)
+	Next() *Server
 }
 
 type RoundRobin struct {
-	round int
-	mu    sync.Mutex
-	log   *slog.Logger
+	round   int
+	servers []*Server
+	mu      sync.Mutex
+	log     *slog.Logger
 }
 
-func New(log *slog.Logger) *RoundRobin {
+func NewRoundRobin(log *slog.Logger) *RoundRobin {
 	return &RoundRobin{
 		log: log,
 	}
 }
 
-func (rr *RoundRobin) Next(servers []*Server) *Server {
+func (rr *RoundRobin) Next() *Server {
 	rr.mu.Lock()
-	if len(servers) == 0 {
-		rr.mu.Unlock()
+	if len(rr.servers) == 0 {
 		return nil
 	}
-	server := servers[rr.round%len(servers)]
+	server := rr.servers[rr.round%len(rr.servers)]
 
 	rr.round++
 	rr.mu.Unlock()
 	if server.Healthy() {
 		return server
 	}
-	rr.log.Warn("server is too slow, trying next", "name", server.name, "avg", server.pings.Last())
-	return rr.Next(servers)
+	rr.log.Warn("server is unhealthy, trying next", "name", server.name)
+	return rr.Next()
+}
+
+func (rr *RoundRobin) Update(servers []*Server) {
+	rr.mu.Lock()
+	rr.servers = servers
+	rr.mu.Unlock()
+}
+
+type LatencyBased struct {
+	servers    []*RatedServer
+	mu         sync.Mutex
+	log        *slog.Logger
+	randomizer *rand.Rand
+}
+
+type RatedServer struct {
+	*Server
+	Rate float64
+}
+
+func NewLatencyBased(log *slog.Logger) *LatencyBased {
+	return &LatencyBased{
+		randomizer: rand.New(rand.NewSource(time.Now().UnixNano())),
+		log:        log,
+	}
+}
+
+func (rr *LatencyBased) Next() *Server {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+
+	r := rr.randomizer.Float64()
+	cumulative := 0.0
+
+	for _, s := range rr.servers {
+		cumulative += s.Rate
+		if r <= cumulative {
+			return s.Server
+		}
+	}
+
+	// Fallback, shouldn't be reached if rates are normalized
+	return rr.servers[len(rr.servers)-1].Server
+}
+
+func (rr *LatencyBased) Update(servers []*Server) {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+
+	var totalInverse float64
+	rr.servers = make([]*RatedServer, len(servers))
+
+	// Avoid division by zero: use a small epsilon if latency is 0
+	const epsilon = 1e-9
+
+	for i := range servers {
+		latency := float64(servers[i].node.Status.Latency.Milliseconds())
+		fmt.Println(latency)
+		if latency == 0 {
+			latency = epsilon
+		}
+		rr.servers[i] = &RatedServer{
+			Server: servers[i],
+			Rate:   1 / latency,
+		}
+		totalInverse += rr.servers[i].Rate
+	}
+
+	// Normalize rates to sum to 1.0
+	for i := range servers {
+		rr.servers[i].Rate /= totalInverse
+	}
 }

--- a/internal/proxy/balancer.go
+++ b/internal/proxy/balancer.go
@@ -1,0 +1,39 @@
+package proxy
+
+import (
+	"log/slog"
+	"sync"
+)
+
+type LoadBalancer interface {
+	Next([]*Server) *Server
+}
+
+type RoundRobin struct {
+	round int
+	mu    sync.Mutex
+	log   *slog.Logger
+}
+
+func New(log *slog.Logger) *RoundRobin {
+	return &RoundRobin{
+		log: log,
+	}
+}
+
+func (rr *RoundRobin) Next(servers []*Server) *Server {
+	rr.mu.Lock()
+	if len(servers) == 0 {
+		rr.mu.Unlock()
+		return nil
+	}
+	server := servers[rr.round%len(servers)]
+
+	rr.round++
+	rr.mu.Unlock()
+	if server.Healthy() {
+		return server
+	}
+	rr.log.Warn("server is too slow, trying next", "name", server.name, "avg", server.pings.Last())
+	return rr.Next(servers)
+}

--- a/internal/proxy/balancer.go
+++ b/internal/proxy/balancer.go
@@ -1,31 +1,48 @@
 package proxy
 
 import (
-	"fmt"
 	"log/slog"
 	"math/rand"
 	"sync"
 	"time"
 )
 
+// epsilon is a small value used to avoid division by zero when calculating rates and
+// used as toleration when comparing floats.
+const epsilon = 1e-9
+
+// LoadBalancer is an interface for load balancing algorithms. It provides
+// methods to update the list of available servers and to select the next
+// server to be used.
 type LoadBalancer interface {
+	// Update updates the list of available servers.
 	Update([]*Server)
+	// Next returns the next server to be used based on the load balancing algorithm.
 	Next() *Server
 }
 
+// RoundRobin is a simple load balancer that distributes incoming requests
+// across multiple servers in a round-robin fashion.
 type RoundRobin struct {
-	round   int
+	// round is the current round number.
+	round int
+	// servers is the list of available servers.
 	servers []*Server
-	mu      sync.Mutex
-	log     *slog.Logger
+	// mu is a mutex to protect access to the RoundRobin struct.
+	mu sync.Mutex
+	// log is a logger to log events.
+	log *slog.Logger
 }
 
+// NewRoundRobin returns a new RoundRobin load balancer instance.
 func NewRoundRobin(log *slog.Logger) *RoundRobin {
 	return &RoundRobin{
 		log: log,
 	}
 }
 
+// Next returns the next server to be used based on the round-robin algorithm.
+// If the selected server is unhealthy, it will recursively try the next server.
 func (rr *RoundRobin) Next() *Server {
 	rr.mu.Lock()
 	if len(rr.servers) == 0 {
@@ -42,24 +59,36 @@ func (rr *RoundRobin) Next() *Server {
 	return rr.Next()
 }
 
+// Update updates the list of available servers.
 func (rr *RoundRobin) Update(servers []*Server) {
 	rr.mu.Lock()
 	rr.servers = servers
 	rr.mu.Unlock()
 }
 
+// LatencyBased is a load balancer that selects servers based on their latency.
+// The latency is represented as a rate, with higher rates indicating lower latency.
 type LatencyBased struct {
-	servers    []*RatedServer
-	mu         sync.Mutex
-	log        *slog.Logger
+	// servers is the list of available servers with their corresponding rates.
+	servers []*RatedServer
+	// mu is a mutex to protect access to the LatencyBased struct.
+	mu sync.Mutex
+	// log is a logger to log events.
+	log *slog.Logger
+	// randomizer is a random number generator used to select servers.
 	randomizer *rand.Rand
 }
 
+// RatedServer represents a server with a rate, which is used to determine its
+// likelihood of being selected by the LatencyBased load balancer.
 type RatedServer struct {
+	// Server is the underlying server instance.
 	*Server
+	// Rate is the rate of the server, representing its latency.
 	Rate float64
 }
 
+// NewLatencyBased returns a new LatencyBased load balancer instance.
 func NewLatencyBased(log *slog.Logger) *LatencyBased {
 	return &LatencyBased{
 		randomizer: rand.New(rand.NewSource(time.Now().UnixNano())),
@@ -67,6 +96,14 @@ func NewLatencyBased(log *slog.Logger) *LatencyBased {
 	}
 }
 
+// Next returns the next server based on the weighted random selection,
+// where the weight is determined by the latency Rate of each server. The cumulative
+// approach is used to select a server, effectively creating a "range" for each
+// server in the interval [0, 1]. For example, if the rates are [0.5, 0.3, 0.2],
+// the ranges would be: Server 1: [0, 0.5), Server 2: [0.5, 0.8), Server 3: [0.8, 1).
+// The random number will fall into one of these ranges, effectively selecting
+// a server based on its latency rate. This approach works regardless of the order of
+// the servers, so there's no need to sort them based on latency or rate.
 func (rr *LatencyBased) Next() *Server {
 	rr.mu.Lock()
 	defer rr.mu.Unlock()
@@ -85,6 +122,11 @@ func (rr *LatencyBased) Next() *Server {
 	return rr.servers[len(rr.servers)-1].Server
 }
 
+// Update updates the list of available servers and their corresponding rates
+// based on their latency. The rate of each server is calculated as the inverse
+// of its latency, and then normalized to ensure that the rates sum to 1.0.
+// This allows the LatencyBased load balancer to select servers based on their
+// relative latency.
 func (rr *LatencyBased) Update(servers []*Server) {
 	rr.mu.Lock()
 	defer rr.mu.Unlock()
@@ -92,15 +134,14 @@ func (rr *LatencyBased) Update(servers []*Server) {
 	var totalInverse float64
 	rr.servers = make([]*RatedServer, len(servers))
 
-	// Avoid division by zero: use a small epsilon if latency is 0
-	const epsilon = 1e-9
-
 	for i := range servers {
+		// Calculate the latency of the server in milliseconds
 		latency := float64(servers[i].node.Status.Latency.Milliseconds())
-		fmt.Println(latency)
+		// Avoid division by zero by using a small epsilon value if latency is 0
 		if latency == 0 {
 			latency = epsilon
 		}
+		// Calculate the rate of the server as the inverse of its latency
 		rr.servers[i] = &RatedServer{
 			Server: servers[i],
 			Rate:   1 / latency,
@@ -108,7 +149,7 @@ func (rr *LatencyBased) Update(servers []*Server) {
 		totalInverse += rr.servers[i].Rate
 	}
 
-	// Normalize rates to sum to 1.0
+	// Normalize the rates to ensure they sum to 1.0
 	for i := range servers {
 		rr.servers[i].Rate /= totalInverse
 	}

--- a/internal/proxy/balancer_test.go
+++ b/internal/proxy/balancer_test.go
@@ -158,11 +158,11 @@ func TestLatencyBased_Next(t *testing.T) {
 		selectedServers[server.name] = selectedServers[server.name] + 1
 	}
 
-	if math.Abs(lb.servers[0].Rate-0.9) > 1e-9 {
+	if math.Abs(lb.servers[0].Rate-0.9) > epsilon {
 		t.Errorf("expected server \"a\" to have a rate of 0.9, got %.2f instead", lb.servers[0].Rate)
 	}
 
-	if math.Abs(lb.servers[1].Rate-0.1) > 1e-9 {
+	if math.Abs(lb.servers[1].Rate-0.1) > epsilon {
 		t.Errorf("expected server \"b\" to have a rate of 0.1, got %.2f instead", lb.servers[1].Rate)
 	}
 

--- a/internal/proxy/balancer_test.go
+++ b/internal/proxy/balancer_test.go
@@ -1,0 +1,176 @@
+package proxy
+
+import (
+	"github.com/akash-network/rpc-proxy/internal/avg"
+	"github.com/akash-network/rpc-proxy/internal/config"
+	"github.com/akash-network/rpc-proxy/internal/seed"
+	"log/slog"
+	"math"
+	"math/rand"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRoundRobin_Next(t *testing.T) {
+	servers := []*Server{
+		{
+			cfg:          config.Config{},
+			name:         "a",
+			Url:          nil,
+			pings:        avg.Moving(1),
+			successes:    nil,
+			failures:     nil,
+			requestCount: atomic.Int64{},
+			log:          nil,
+			node: seed.Node{
+				Status: seed.Status{
+					Reachable:     true,
+					CatchingUp:    false,
+					IsLatestBlock: true,
+					Latency:       0,
+				},
+			},
+		},
+		{
+			cfg:          config.Config{},
+			name:         "b",
+			Url:          nil,
+			pings:        avg.Moving(1),
+			successes:    nil,
+			failures:     nil,
+			requestCount: atomic.Int64{},
+			log:          nil,
+			node: seed.Node{
+				Status: seed.Status{
+					Reachable:     true,
+					CatchingUp:    false,
+					IsLatestBlock: true,
+					Latency:       0,
+				},
+			},
+		},
+	}
+
+	lb := NewRoundRobin(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	lb.Update(servers)
+	n := 5 // Number of times to loop in each goroutine
+	goroutines := 2
+	var wg sync.WaitGroup
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < n; j++ {
+				t.Logf("goroutine %d: ", id)
+				lb.Next()
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	if lb.round != n*goroutines {
+		t.Errorf("expected %d rounds but got %d", n*goroutines, lb.round)
+	}
+}
+
+func TestLatencyBased_Next(t *testing.T) {
+	servers := []*Server{
+		{
+			cfg:          config.Config{},
+			name:         "a",
+			Url:          nil,
+			pings:        avg.Moving(1),
+			successes:    nil,
+			failures:     nil,
+			requestCount: atomic.Int64{},
+			log:          nil,
+			node: seed.Node{
+				Status: seed.Status{
+					Reachable:     true,
+					CatchingUp:    false,
+					IsLatestBlock: true,
+					Latency:       10 * time.Millisecond,
+				},
+			},
+		},
+		{
+			cfg:          config.Config{},
+			name:         "b",
+			Url:          nil,
+			pings:        avg.Moving(1),
+			successes:    nil,
+			failures:     nil,
+			requestCount: atomic.Int64{},
+			log:          nil,
+			node: seed.Node{
+				Status: seed.Status{
+					Reachable:     true,
+					CatchingUp:    false,
+					IsLatestBlock: true,
+					Latency:       90 * time.Millisecond,
+				},
+			},
+		},
+	}
+
+	lb := NewLatencyBased(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	lb.randomizer = rand.New(rand.NewSource(0))
+	lb.Update(servers)
+
+	sum := 0.0
+	for _, server := range lb.servers {
+		sum += server.Rate
+	}
+
+	if sum != 1.0 {
+		t.Errorf("rates are not normalized, sum should be 1, got %f", sum)
+	}
+
+	n := 5 // Number of times to loop in each goroutine
+	goroutines := 2
+	var wg sync.WaitGroup
+
+	selectedServers := make(map[string]int)
+	queue := make(chan *Server, 1)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			for j := 0; j < n; j++ {
+				t.Logf("goroutine %d: ", id)
+				queue <- lb.Next()
+			}
+			wg.Done()
+		}(i)
+	}
+
+	go func() {
+		wg.Wait()
+		close(queue)
+	}()
+
+	for server := range queue {
+		selectedServers[server.name] = selectedServers[server.name] + 1
+	}
+
+	if math.Abs(lb.servers[0].Rate-0.9) > 1e-9 {
+		t.Errorf("expected server \"a\" to have a rate of 0.9, got %.2f instead", lb.servers[0].Rate)
+	}
+
+	if math.Abs(lb.servers[1].Rate-0.1) > 1e-9 {
+		t.Errorf("expected server \"b\" to have a rate of 0.1, got %.2f instead", lb.servers[1].Rate)
+	}
+
+	if selectedServers["a"] != 9 {
+		t.Errorf("expected server \"a\" to be selected 9 time, got selected %d times", selectedServers["a"])
+	}
+
+	if selectedServers["b"] != 1 {
+		t.Errorf("expected server \"b\" to be selected 1 time, got selected %d times", selectedServers["b"])
+	}
+}

--- a/internal/proxy/grpc.go
+++ b/internal/proxy/grpc.go
@@ -10,25 +10,34 @@ import (
 	"github.com/akash-network/rpc-proxy/internal/seed"
 )
 
+// GRPCProxy is a wrapper around Proxy that provides gRPC-specific behavior.
+// It embeds the Proxy struct to reuse its core logic and configuration.
 type GRPCProxy struct {
 	Proxy
 }
 
+// NewGRPCProxy creates and returns a new instance of GRPCProxy.
+// It initializes the embedded Proxy with the given seed channel,
+// configuration, logger, and a custom load balancer.
 func NewGRPCProxy(
 	ch chan seed.Seed,
 	cfg config.Config,
 	log *slog.Logger,
+	lb LoadBalancer,
 ) *GRPCProxy {
 	return &GRPCProxy{
 		Proxy: Proxy{
 			cfg: cfg,
 			ch:  ch,
 			log: log,
-			lb:  NewRoundRobin(log),
+			lb:  lb,
 		},
 	}
 }
 
+// ServeHTTP handles incoming HTTP requests for the GRPCProxy.
+// It satisfies the http.Handler interface, allowing GRPCProxy to be used
+// directly with an HTTP server (e.g., http.ListenAndServe).
 func (p *GRPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.shuttingDown.Load() {
 		p.log.Error("proxy is shutting down")
@@ -70,6 +79,9 @@ func (p *GRPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusInternalServerError)
 }
 
+// Start begins the lifecycle of the GRPCProxy.
+// It delegates to the embedded Proxy's Start method, passing in the context
+// and the GRPCProxy's update function.
 func (p *GRPCProxy) Start(ctx context.Context) {
 	p.Proxy.Start(ctx, p.update)
 }

--- a/internal/proxy/grpc.go
+++ b/internal/proxy/grpc.go
@@ -24,7 +24,7 @@ func NewGRPCProxy(
 			cfg: cfg,
 			ch:  ch,
 			log: log,
-			lb:  New(log),
+			lb:  NewRoundRobin(log),
 		},
 	}
 }
@@ -36,7 +36,7 @@ func (p *GRPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if srv := p.lb.Next(p.servers); srv != nil {
+	if srv := p.lb.Next(); srv != nil {
 
 		// Create the reverse proxy
 		proxy := httputil.ReverseProxy{

--- a/internal/proxy/grpc.go
+++ b/internal/proxy/grpc.go
@@ -24,6 +24,7 @@ func NewGRPCProxy(
 			cfg: cfg,
 			ch:  ch,
 			log: log,
+			lb:  New(log),
 		},
 	}
 }
@@ -35,7 +36,7 @@ func (p *GRPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if srv := p.next(); srv != nil {
+	if srv := p.lb.Next(p.servers); srv != nil {
 
 		// Create the reverse proxy
 		proxy := httputil.ReverseProxy{

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math/rand"
 	"net/url"
 	"slices"
 	"sort"
@@ -22,12 +21,11 @@ type Proxy struct {
 	init sync.Once
 	ch   chan seed.Seed
 
-	round   int
-	mu      sync.Mutex
 	servers []*Server
 
 	initialized  atomic.Bool
 	shuttingDown atomic.Bool
+	lb           LoadBalancer
 }
 
 type Updater func(s seed.Seed)
@@ -53,30 +51,7 @@ func (p *Proxy) Stats() []ServerStat {
 	return result
 }
 
-func (p *Proxy) next() *Server {
-	p.mu.Lock()
-	if len(p.servers) == 0 {
-		p.mu.Unlock()
-		return nil
-	}
-	server := p.servers[p.round%len(p.servers)]
-
-	p.round++
-	p.mu.Unlock()
-	if server.Healthy() && server.ErrorRate() <= p.cfg.HealthyErrorRateThreshold {
-		return server
-	}
-	if rand.Intn(99)+1 < p.cfg.UnhealthyServerRecoverChancePct {
-		p.log.Warn("giving slow server a chance", "name", server.name, "avg", server.pings.Last())
-		return server
-	}
-	p.log.Warn("server is too slow, trying next", "name", server.name, "avg", server.pings.Last())
-	return p.next()
-}
-
 func (p *Proxy) doUpdate(providers []seed.Node) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
 
 	// add new servers
 	for _, provider := range providers {
@@ -90,7 +65,6 @@ func (p *Proxy) doUpdate(providers []seed.Node) error {
 			return err
 		}
 
-		// TODO: check health before creating new server
 		idx := slices.IndexFunc(p.servers, func(srv *Server) bool { return srv.name == provider.Provider })
 		if idx == -1 {
 			srv, err := newServer(
@@ -121,13 +95,13 @@ func (p *Proxy) doUpdate(providers []seed.Node) error {
 				}
 				return false
 			}
-
 		}
 		p.log.Info("server was removed from pool", "name", srv.name)
 		return true
 	})
 
 	p.initialized.Store(true)
+
 	return nil
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -72,6 +72,7 @@ func (p *Proxy) doUpdate(providers []seed.Node) error {
 				target,
 				p.cfg,
 				p.log.With("server_address", provider.Address),
+				provider,
 			)
 			if err != nil {
 				return err
@@ -85,7 +86,7 @@ func (p *Proxy) doUpdate(providers []seed.Node) error {
 	p.servers = slices.DeleteFunc(p.servers, func(srv *Server) bool {
 		for _, provider := range providers {
 			if provider.Provider == srv.name {
-				if provider.Healthy() { // provider matches but is unhealthy.
+				if !provider.Healthy() { // provider matches but is unhealthy.
 					p.log.Info("unhealthy server removed from pool",
 						"name", srv.name,
 						"catching_up", provider.Status.CatchingUp,
@@ -101,6 +102,7 @@ func (p *Proxy) doUpdate(providers []seed.Node) error {
 	})
 
 	p.initialized.Store(true)
+	p.lb.Update(p.servers)
 
 	return nil
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -20,6 +20,8 @@ import (
 func TestRPCProxy(t *testing.T) {
 	serverList := generateServerList(t)
 
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ch := make(chan seed.Seed, 1)
@@ -29,7 +31,7 @@ func TestRPCProxy(t *testing.T) {
 		UnhealthyServerRecoverChancePct: 1,
 		HealthyErrorRateThreshold:       10,
 		HealthyErrorRateBucketTimeout:   time.Second * 10,
-	}, slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	}, logger, NewRoundRobin(logger))
 
 	proxy.Start(ctx)
 
@@ -77,6 +79,7 @@ func TestRPCProxy(t *testing.T) {
 
 func TestRestProxy(t *testing.T) {
 	serverList := generateServerList(t)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -87,7 +90,7 @@ func TestRestProxy(t *testing.T) {
 		UnhealthyServerRecoverChancePct: 1,
 		HealthyErrorRateThreshold:       10,
 		HealthyErrorRateBucketTimeout:   time.Second * 10,
-	}, slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	}, logger, NewRoundRobin(logger))
 
 	proxy.Start(ctx)
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -70,7 +70,7 @@ func TestRPCProxy(t *testing.T) {
 	require.Greater(t, srv1Stats.Requests, srv2Stats.Requests)
 	require.Greater(t, srv2Stats.Avg, srv1Stats.Avg)
 	require.False(t, srv1Stats.Degraded)
-	require.True(t, srv2Stats.Degraded)
+	require.False(t, srv2Stats.Degraded)
 	require.True(t, srv1Stats.Initialized)
 	require.True(t, srv2Stats.Initialized)
 }
@@ -128,7 +128,7 @@ func TestRestProxy(t *testing.T) {
 	require.Greater(t, srv1Stats.Requests, srv2Stats.Requests)
 	require.Greater(t, srv2Stats.Avg, srv1Stats.Avg)
 	require.False(t, srv1Stats.Degraded)
-	require.True(t, srv2Stats.Degraded)
+	require.False(t, srv2Stats.Degraded)
 	require.True(t, srv1Stats.Initialized)
 	require.True(t, srv2Stats.Initialized)
 }

--- a/internal/proxy/rest.go
+++ b/internal/proxy/rest.go
@@ -23,6 +23,7 @@ func NewRestProxy(
 			cfg: cfg,
 			ch:  ch,
 			log: log,
+			lb:  New(log),
 		},
 	}
 }
@@ -35,7 +36,7 @@ func (p *RestProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/rest")
-	if srv := p.next(); srv != nil {
+	if srv := p.lb.Next(p.servers); srv != nil {
 		srv.ServeHTTP(w, r)
 		return
 	}

--- a/internal/proxy/rest.go
+++ b/internal/proxy/rest.go
@@ -9,25 +9,34 @@ import (
 	"strings"
 )
 
+// RestProxy is a wrapper around Proxy that provides REST-specific behavior.
+// It embeds the Proxy struct to reuse shared logic and configuration.
 type RestProxy struct {
 	Proxy
 }
 
+// NewRestProxy creates and returns a new instance of RestProxy.
+// It initializes the embedded Proxy with the given seed channel,
+// configuration, logger, and load balancer.
 func NewRestProxy(
 	ch chan seed.Seed,
 	cfg config.Config,
 	log *slog.Logger,
+	lb LoadBalancer,
 ) *RestProxy {
 	return &RestProxy{
 		Proxy: Proxy{
 			cfg: cfg,
 			ch:  ch,
 			log: log,
-			lb:  NewRoundRobin(log),
+			lb:  lb,
 		},
 	}
 }
 
+// ServeHTTP handles incoming HTTP requests for the RestProxy.
+// It satisfies the http.Handler interface, allowing RestProxy to be used
+// directly with an HTTP server (e.g., http.ListenAndServe).
 func (p *RestProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.shuttingDown.Load() {
 		p.log.Error("proxy is shutting down")
@@ -45,6 +54,9 @@ func (p *RestProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusInternalServerError)
 }
 
+// Start begins the lifecycle of the RestProxy.
+// It delegates to the embedded Proxy's Start method, passing in the context
+// and the RestProxy's update function.
 func (p *RestProxy) Start(ctx context.Context) {
 	p.Proxy.Start(ctx, p.update)
 }

--- a/internal/proxy/rest.go
+++ b/internal/proxy/rest.go
@@ -23,7 +23,7 @@ func NewRestProxy(
 			cfg: cfg,
 			ch:  ch,
 			log: log,
-			lb:  New(log),
+			lb:  NewRoundRobin(log),
 		},
 	}
 }
@@ -36,7 +36,7 @@ func (p *RestProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/rest")
-	if srv := p.lb.Next(p.servers); srv != nil {
+	if srv := p.lb.Next(); srv != nil {
 		srv.ServeHTTP(w, r)
 		return
 	}

--- a/internal/proxy/rpc.go
+++ b/internal/proxy/rpc.go
@@ -23,7 +23,7 @@ func NewRPCProxy(
 			cfg: cfg,
 			ch:  ch,
 			log: log,
-			lb:  New(log),
+			lb:  NewRoundRobin(log),
 		},
 	}
 }
@@ -36,7 +36,7 @@ func (p *RPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/rpc")
-	if srv := p.lb.Next(p.servers); srv != nil {
+	if srv := p.lb.Next(); srv != nil {
 		srv.ServeHTTP(w, r)
 		return
 	}

--- a/internal/proxy/rpc.go
+++ b/internal/proxy/rpc.go
@@ -9,25 +9,34 @@ import (
 	"strings"
 )
 
+// RPCProxy is a wrapper around Proxy that provides RPC-specific functionality.
+// It embeds the Proxy struct, inheriting its fields and behavior.
 type RPCProxy struct {
 	Proxy
 }
 
+// NewRPCProxy creates and returns a new instance of RPCProxy.
+// It initializes the embedded Proxy with the provided configuration,
+// seed channel, logger, and a load balancer.
 func NewRPCProxy(
 	ch chan seed.Seed,
 	cfg config.Config,
 	log *slog.Logger,
+	lb LoadBalancer,
 ) *RPCProxy {
 	return &RPCProxy{
 		Proxy: Proxy{
 			cfg: cfg,
 			ch:  ch,
 			log: log,
-			lb:  NewRoundRobin(log),
+			lb:  lb,
 		},
 	}
 }
 
+// ServeHTTP handles incoming HTTP requests for the RPCProxy.
+// It satisfies the http.Handler interface, allowing RPCProxy to be used
+// directly with an HTTP server (e.g., http.ListenAndServe).
 func (p *RPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.shuttingDown.Load() {
 		p.log.Error("proxy is shutting down")
@@ -45,6 +54,9 @@ func (p *RPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusInternalServerError)
 }
 
+// Start begins the lifecycle of the RPCProxy.
+// It delegates to the embedded Proxy's Start method, passing in the context
+// and the GRPCProxy's update function.
 func (p *RPCProxy) Start(ctx context.Context) {
 	p.Proxy.Start(ctx, p.update)
 }

--- a/internal/proxy/rpc.go
+++ b/internal/proxy/rpc.go
@@ -23,6 +23,7 @@ func NewRPCProxy(
 			cfg: cfg,
 			ch:  ch,
 			log: log,
+			lb:  New(log),
 		},
 	}
 }
@@ -35,7 +36,7 @@ func (p *RPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/rpc")
-	if srv := p.next(); srv != nil {
+	if srv := p.lb.Next(p.servers); srv != nil {
 		srv.ServeHTTP(w, r)
 		return
 	}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"github.com/akash-network/rpc-proxy/internal/seed"
 	"io"
 	"log/slog"
 	"net/http"
@@ -16,7 +17,7 @@ import (
 
 // TODO: Replace these stats with prometheus metrics server.
 
-func newServer(name string, target *url.URL, cfg config.Config, log *slog.Logger) (*Server, error) {
+func newServer(name string, target *url.URL, cfg config.Config, log *slog.Logger, node seed.Node) (*Server, error) {
 	return &Server{
 		name:      name,
 		Url:       target,
@@ -25,6 +26,7 @@ func newServer(name string, target *url.URL, cfg config.Config, log *slog.Logger
 		successes: ttlslice.New[int](),
 		failures:  ttlslice.New[int](),
 		log:       log,
+		node:      node,
 	}, nil
 }
 
@@ -37,6 +39,7 @@ type Server struct {
 	failures     *ttlslice.Slice[int]
 	requestCount atomic.Int64
 	log          *slog.Logger
+	node         seed.Node
 }
 
 func (s *Server) ErrorRate() float64 {
@@ -50,8 +53,7 @@ func (s *Server) ErrorRate() float64 {
 }
 
 func (s *Server) Healthy() bool {
-	return s.pings.Last() < s.cfg.HealthyThreshold &&
-		s.ErrorRate() < s.cfg.HealthyErrorRateThreshold
+	return s.node.Healthy()
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/seed/probes.go
+++ b/internal/seed/probes.go
@@ -38,6 +38,7 @@ func (f ProbeFunc) Probe(ctx context.Context, node Node) (Status, error) {
 // RPCProbe probes an RPC Node.
 // It queries the Node status through RPC and tries to set the latest block height globally.
 func RPCProbe(ctx context.Context, node Node) (Status, error) {
+	start := time.Now()
 	client, err := rpchttp.New(node.Address, "/")
 	if err != nil {
 		return Status{}, fmt.Errorf("getting RPC client status: %w", err)
@@ -54,6 +55,7 @@ func RPCProbe(ctx context.Context, node Node) (Status, error) {
 		CatchingUp:    status.SyncInfo.CatchingUp,
 		Reachable:     true,
 		IsLatestBlock: errLowBlock == nil,
+		Latency:       time.Since(start),
 	}, nil
 }
 
@@ -61,6 +63,7 @@ func RPCProbe(ctx context.Context, node Node) (Status, error) {
 // It checks if the node is catching up, queries the Node status through gRPC and tries to set the latest block
 // height globally.
 func GRPCProbe(ctx context.Context, node Node) (Status, error) {
+	start := time.Now()
 	creds := credentials.NewTLS(&tls.Config{
 		InsecureSkipVerify: false,
 	})
@@ -92,6 +95,7 @@ func GRPCProbe(ctx context.Context, node Node) (Status, error) {
 		CatchingUp:    catchingUp.Syncing,
 		Reachable:     true,
 		IsLatestBlock: errLowBlock == nil,
+		Latency:       time.Since(start),
 	}, nil
 }
 
@@ -111,6 +115,8 @@ type latestBlockResponse struct {
 // It checks if the node is catching up querying the REST endpoint, queries the Node latest block and tries to set the
 // height globally.
 func RESTProbe(ctx context.Context, node Node) (Status, error) {
+	start := time.Now()
+
 	client := &http.Client{}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/syncing", node.Address), nil)
@@ -174,5 +180,6 @@ func RESTProbe(ctx context.Context, node Node) (Status, error) {
 		CatchingUp:    syncing.CatchingUp,
 		Reachable:     true,
 		IsLatestBlock: errLowBlock == nil,
+		Latency:       time.Since(start),
 	}, nil
 }

--- a/internal/seed/probes.go
+++ b/internal/seed/probes.go
@@ -5,14 +5,16 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/akash-network/rpc-proxy/internal/block"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"io"
-	"net/http"
-	"time"
 )
 
 // Probe is the interface that wraps the Probe method.
@@ -91,17 +93,24 @@ func GRPCProbe(ctx context.Context, node Node) (Status, error) {
 		Reachable:     true,
 		IsLatestBlock: errLowBlock == nil,
 	}, nil
+}
 
+type syncInfoResponse struct {
+	CatchingUp bool `json:"catching_up"`
+}
+
+type latestBlockResponse struct {
+	Block struct {
+		Header struct {
+			Height string `json:"height"`
+		} `json:"header"`
+	} `json:"block"`
 }
 
 // RESTProbe probes a REST Node.
 // It checks if the node is catching up querying the REST endpoint, queries the Node latest block and tries to set the
 // height globally.
 func RESTProbe(ctx context.Context, node Node) (Status, error) {
-	type SyncInfo struct {
-		CatchingUp bool `json:"catching_up"`
-	}
-
 	client := &http.Client{}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/syncing", node.Address), nil)
@@ -124,7 +133,7 @@ func RESTProbe(ctx context.Context, node Node) (Status, error) {
 		return Status{}, fmt.Errorf("reading body from REST client response: %w", err)
 	}
 
-	var syncing SyncInfo
+	var syncing syncInfoResponse
 	if err := json.Unmarshal(body, &syncing); err != nil {
 		return Status{}, fmt.Errorf("unmarshaling body from REST client response: %w", err)
 	}
@@ -149,12 +158,17 @@ func RESTProbe(ctx context.Context, node Node) (Status, error) {
 		return Status{}, fmt.Errorf("reading body from REST client response: %w", err)
 	}
 
-	var latestBlock cmtservice.GetLatestBlockResponse
+	var latestBlock latestBlockResponse
 	if err := json.Unmarshal(latestBlockBody, &latestBlock); err != nil {
 		return Status{}, fmt.Errorf("unmarshaling body from REST client response: %w", err)
 	}
 
-	errLowBlock := block.GetInstance().SetLatestBlock(latestBlock.Block.Header.Height)
+	height, err := strconv.ParseInt(latestBlock.Block.Header.Height, 10, 64)
+	if err != nil {
+		return Status{}, fmt.Errorf("parsing block height: %w", err)
+	}
+
+	errLowBlock := block.GetInstance().SetLatestBlock(height)
 
 	return Status{
 		CatchingUp:    syncing.CatchingUp,

--- a/internal/seed/seed.go
+++ b/internal/seed/seed.go
@@ -135,7 +135,11 @@ func (s *Seeder) fetch(ctx context.Context, log *slog.Logger, url string) (Seed,
 			continue
 		}
 
-		log.Info("added RPC server", "name", rpcProxy.Provider, "catching_up", status.CatchingUp, "latest_block", status.IsLatestBlock)
+		log.Info("added RPC server",
+			"name", rpcProxy.Provider,
+			"catching_up", status.CatchingUp,
+			"latest_block", status.IsLatestBlock,
+			"latency", fmt.Sprintf("%dms", status.Latency.Milliseconds()))
 		seed.APIs.RPC[i] = rpcProxy.WithStatus(status)
 	}
 
@@ -147,7 +151,11 @@ func (s *Seeder) fetch(ctx context.Context, log *slog.Logger, url string) (Seed,
 			continue
 		}
 
-		log.Info("added REST server", "name", restProxy.Provider, "catching_up", status.CatchingUp, "latest_block", status.IsLatestBlock)
+		log.Info("added REST server",
+			"name", restProxy.Provider,
+			"catching_up", status.CatchingUp,
+			"latest_block", status.IsLatestBlock,
+			"latency", fmt.Sprintf("%dms", status.Latency.Milliseconds()))
 		seed.APIs.Rest[i] = restProxy.WithStatus(status)
 	}
 
@@ -159,7 +167,11 @@ func (s *Seeder) fetch(ctx context.Context, log *slog.Logger, url string) (Seed,
 			continue
 		}
 
-		log.Info("added gRPC server", "name", grpcProxy.Provider, "catching_up", status.CatchingUp, "latest_block", status.IsLatestBlock)
+		log.Info("added gRPC server",
+			"name", grpcProxy.Provider,
+			"catching_up", status.CatchingUp,
+			"latest_block", status.IsLatestBlock,
+			"latency", fmt.Sprintf("%dms", status.Latency.Milliseconds()))
 		seed.APIs.GRPC[i] = grpcProxy.WithStatus(status)
 	}
 

--- a/internal/seed/seed.go
+++ b/internal/seed/seed.go
@@ -37,6 +37,8 @@ type Status struct {
 	// block.ErrBlockTooLow when setting the height, it means the node that we queried after was actually not on the latest block yet
 	// and is removed from the seed temporarily.
 	IsLatestBlock bool
+	// Latency ...
+	Latency time.Duration
 }
 
 type Apis struct {
@@ -173,5 +175,5 @@ func (p Node) WithStatus(status Status) Node {
 }
 
 func (p Node) Healthy() bool {
-	return p.Status.CatchingUp || !p.Status.Reachable || !p.Status.IsLatestBlock
+	return !p.Status.CatchingUp && p.Status.Reachable && p.Status.IsLatestBlock
 }


### PR DESCRIPTION
This PR adds the implementation of a Latency-based load balancer to the proxies. It also allows proxies to be configured with different load balancer types depending on the use case.

To implement a custom load balancer simply implement the `LoadBalancer` interface, and pass it to the `Proxy` creation.