### PR TITLE
feat: add viper and cobra for configuration management and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,57 @@
-# Proxy
+# Akash RPC Proxy
 
-Load balancer and proxy for the akash network.
+A proxy server for Akash RPC nodes that provides load balancing and automatic failover.
 
-See [config.md](./config.md) for configuration details.
+## Features
 
----
+- Load balancing across multiple RPC nodes
+- Automatic failover when nodes become unhealthy
+- Support for both HTTP and gRPC endpoints
+- Automatic TLS certificate management via Let's Encrypt
+- Configurable health checks and error rate thresholds
 
-## HTTPS Localhost
+## Running the Proxy
 
-Easiest way is to use [mkcert](https://github.com/FiloSottile/mkcert).
-Make sure to install the untrusted localhost certificate with `mkcert -install`.
+### Basic Usage
 
-Create the certificate and key, and set them:
-
-```sh
-mkcert localhost
-mkcert -install
-
-export AKASH_PROXY_TLS_KEY=localhost-key.pem
-export AKASH_PROXY_TLS_CERT=localhost.pem
+```bash
+# Run with default settings
+go run cmd/main.go
 ```
 
-And start the server by running `go run cmd/main.go`.
+### With TLS Certificates
 
-## Testing
+You can run the proxy with TLS certificates in two ways:
 
-Test the proxy by running `grpcurl localhost:9090 list`.
+1. Using Let's Encrypt (automatic certificate management):
+```bash
+go run cmd/main.go \
+  --autocert-email=your-email@example.com \
+  --autocert-hosts=your-domain.com,another-domain.com
+```
+
+2. Using your own certificates:
+```bash
+# Using localhost certificates (for development)
+go run cmd/main.go \
+  --tls-cert=./localhost.pem \
+  --tls-key=./localhost-key.pem
+
+# Or using environment variables
+export AKASH_PROXY_TLS_CERT=localhost.pem
+export AKASH_PROXY_TLS_KEY=localhost-key.pem
+go run cmd/main.go
+
+# Or using a config file
+go run cmd/main.go --config=./config/local.yaml
+```
+
+## Building
+
+```bash
+go build -o akash-rpc-proxy
+```
+
+## License
+
+MIT

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,6 +69,9 @@ func init() {
 	rootCmd.PersistentFlags().String("seed.url", "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/chain.json", "URL to fetch initial node list")
 	rootCmd.PersistentFlags().Duration("seed.refresh-interval", 5*time.Minute, "How often to refresh node list")
 	rootCmd.PersistentFlags().String("seed.chain-id", "akashnet-2", "Expected chain ID")
+	rootCmd.PersistentFlags().StringSlice("seed.additional-nodes.rpc", []string{}, "Comma-separated list of additional RPC nodes")
+	rootCmd.PersistentFlags().StringSlice("seed.additional-nodes.rest", []string{}, "Comma-separated list of additional REST nodes")
+	rootCmd.PersistentFlags().StringSlice("seed.additional-nodes.grpc", []string{}, "Comma-separated list of additional gRPC nodes")
 
 	// Health configuration
 	rootCmd.PersistentFlags().Duration("health.healthy-threshold", 10*time.Second, "Response time threshold for healthy nodes")
@@ -125,6 +128,15 @@ func runProxy() {
 		SeedURL:             cfg.Seed.URL,
 		SeedRefreshInterval: cfg.Seed.RefreshInterval,
 		ChainID:             cfg.Seed.ChainID,
+		AdditionalNodes: struct {
+			RPC  []string
+			REST []string
+			GRPC []string
+		}{
+			RPC:  cfg.Seed.AdditionalNodes.RPC,
+			REST: cfg.Seed.AdditionalNodes.REST,
+			GRPC: cfg.Seed.AdditionalNodes.GRPC,
+		},
 	}
 	seeder := seed.New(seederCfg, log, rpcListener, restListener, grpcListener)
 	rpcProxyHandler := proxy.NewRPCProxy(rpcListener, cfg.Health, log, proxy.NewLatencyBased(log))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,14 +4,20 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"github.com/akash-network/rpc-proxy/internal/proxy/cors"
+	"fmt"
 	"html/template"
+	"log"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/akash-network/rpc-proxy/internal/proxy/cors"
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -20,15 +26,95 @@ import (
 	"github.com/akash-network/rpc-proxy/internal/config"
 	"github.com/akash-network/rpc-proxy/internal/proxy"
 	"github.com/akash-network/rpc-proxy/internal/seed"
+	"github.com/spf13/cobra"
 	"golang.org/x/crypto/acme/autocert"
 )
 
 //go:embed index.html
 var index []byte
 
-func main() {
-	cfg := config.Must()
-	// TODO: Logging configurations through context propagation??
+var V = viper.New()
+
+var rootCmd = &cobra.Command{
+	Use:   "akash-proxy",
+	Short: "Akash Proxy - A load balancer and proxy for Akash network nodes",
+	Long:  "Akash Proxy provides load balancing and automatic failover for Akash network RPC, gRPC and REST nodes.",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		err := initConfig(cmd)
+		if err != nil {
+			panic(err)
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		runProxy()
+	},
+}
+
+func init() {
+
+	// Server configuration
+	rootCmd.PersistentFlags().String("server.listen", ":25567", "Address to listen on for HTTP REST & RPC requests")
+	rootCmd.PersistentFlags().String("server.listen-grpc", ":9090", "Address to listen on for gRPC requests")
+	rootCmd.PersistentFlags().Duration("server.timeouts.read", 10*time.Second, "Server read timeout")
+	rootCmd.PersistentFlags().Duration("server.timeouts.write", 10*time.Second, "Server write timeout")
+	rootCmd.PersistentFlags().Duration("server.timeouts.idle", 10*time.Second, "Server idle timeout")
+
+	// TLS configuration
+	rootCmd.PersistentFlags().String("tls.autocert.email", "", "Email for Let's Encrypt certificates")
+	rootCmd.PersistentFlags().StringSlice("tls.autocert.hosts", []string{}, "Comma-separated list of domains for Let's Encrypt")
+	rootCmd.PersistentFlags().String("tls.cert", "", "Path to TLS certificate file")
+	rootCmd.PersistentFlags().String("tls.key", "", "Path to TLS private key file")
+
+	// Seed configuration
+	rootCmd.PersistentFlags().String("seed.url", "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/chain.json", "URL to fetch initial node list")
+	rootCmd.PersistentFlags().Duration("seed.refresh-interval", 5*time.Minute, "How often to refresh node list")
+	rootCmd.PersistentFlags().String("seed.chain-id", "akashnet-2", "Expected chain ID")
+
+	// Health configuration
+	rootCmd.PersistentFlags().Duration("health.healthy-threshold", 10*time.Second, "Response time threshold for healthy nodes")
+	rootCmd.PersistentFlags().Duration("health.proxy-request-timeout", 15*time.Second, "Timeout for proxied requests")
+
+	// CORS configuration
+	rootCmd.PersistentFlags().String("cors.allow-origin", "*", "CORS allowed origin")
+	rootCmd.PersistentFlags().String("cors.allow-methods", "GET, POST, PUT, DELETE, OPTIONS", "CORS allowed methods")
+	rootCmd.PersistentFlags().String("cors.allow-headers", "Content-Type, Authorization", "CORS allowed headers")
+
+	// Configuration file support
+	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.akash-proxy/config.yaml)")
+}
+
+func initConfig(cmd *cobra.Command) error {
+	V.SetEnvPrefix("AKASH_PROXY")
+	V.SetEnvKeyReplacer(config.Replacer)
+	V.AutomaticEnv()
+
+	configPath := cmd.Flags().Lookup("config").Value.String()
+	if configPath != "" {
+		V.SetConfigFile(configPath)
+	} else {
+		V.SetConfigName("config")
+		V.SetConfigType("yaml")
+		V.AddConfigPath(".")
+		V.AddConfigPath(filepath.Join("$HOME", ".akash-proxy"))
+	}
+
+	// If a config file is found, read it in.
+	if err := V.ReadInConfig(); err != nil {
+		var configFileNotFoundError viper.ConfigFileNotFoundError
+		if !errors.As(err, &configFileNotFoundError) {
+			return fmt.Errorf("reading configuration: %w", err)
+		}
+	}
+
+	if err := V.BindPFlags(cmd.PersistentFlags()); err != nil {
+		return fmt.Errorf("binding flags %w", err)
+	}
+
+	return nil
+}
+
+func runProxy() {
+	cfg := config.Must(V)
 	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
 	rpcListener := make(chan seed.Seed, 1)
@@ -36,14 +122,14 @@ func main() {
 	grpcListener := make(chan seed.Seed, 1)
 
 	seederCfg := seed.Config{
-		SeedURL:             cfg.SeedURL,
-		SeedRefreshInterval: cfg.SeedRefreshInterval,
-		ChainID:             cfg.ChainID,
+		SeedURL:             cfg.Seed.URL,
+		SeedRefreshInterval: cfg.Seed.RefreshInterval,
+		ChainID:             cfg.Seed.ChainID,
 	}
 	seeder := seed.New(seederCfg, log, rpcListener, restListener, grpcListener)
-	rpcProxyHandler := proxy.NewRPCProxy(rpcListener, cfg, log, proxy.NewLatencyBased(log))
-	restProxyHandler := proxy.NewRestProxy(restListener, cfg, log, proxy.NewLatencyBased(log))
-	grpcProxyHandler := proxy.NewGRPCProxy(grpcListener, cfg, log, proxy.NewLatencyBased(log))
+	rpcProxyHandler := proxy.NewRPCProxy(rpcListener, cfg.Health, log, proxy.NewLatencyBased(log))
+	restProxyHandler := proxy.NewRestProxy(restListener, cfg.Health, log, proxy.NewLatencyBased(log))
+	grpcProxyHandler := proxy.NewGRPCProxy(grpcListener, log, proxy.NewLatencyBased(log))
 
 	ctx, proxyCtxCancel := context.WithCancel(context.Background())
 	defer proxyCtxCancel()
@@ -79,8 +165,8 @@ func main() {
 	proxyGroup.Go(func() error {
 		log.Info("starting server", "addr", srv.Addr)
 		var err error
-		if cfg.Listen == ":https" {
-			err = srv.ListenAndServeTLS(cfg.TLSCert, cfg.TLSKey)
+		if cfg.Server.Listen == ":https" {
+			err = srv.ListenAndServeTLS(cfg.TLS.Cert, cfg.TLS.Key)
 		} else {
 			err = srv.ListenAndServe()
 		}
@@ -98,7 +184,7 @@ func main() {
 
 	proxyGroup.Go(func() error {
 		log.Info("starting grpc proxy", "addr", grpcServer.Addr)
-		err := grpcServer.ListenAndServeTLS(cfg.TLSCert, cfg.TLSKey)
+		err := grpcServer.ListenAndServeTLS(cfg.TLS.Cert, cfg.TLS.Key)
 		if err != nil {
 			if errors.Is(err, http.ErrServerClosed) {
 				log.Info("server shut down")
@@ -116,15 +202,21 @@ func main() {
 	}
 }
 
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatalf("failed to execute command: %v", err)
+	}
+}
+
 func prepareRestAndRPCServer(log *slog.Logger, cfg config.Config, rpcProxyHandler *proxy.RPCProxy, restProxyHandler *proxy.RestProxy) *http.Server {
 	am := autocert.Manager{
 		Cache:  autocert.DirCache("."),
 		Prompt: autocert.AcceptTOS,
 	}
-	if addr := cfg.AutocertEmail; addr != "" {
+	if addr := cfg.TLS.Autocert.Email; addr != "" {
 		am.Email = addr
 	}
-	if hosts := cfg.AutocertHosts; len(hosts) > 0 {
+	if hosts := cfg.TLS.Autocert.Hosts; len(hosts) > 0 {
 		am.HostPolicy = autocert.HostWhitelist(hosts...)
 	}
 
@@ -154,23 +246,22 @@ func prepareRestAndRPCServer(log *slog.Logger, cfg config.Config, rpcProxyHandle
 		}
 	}))
 
-	// TODO: make this part of the configuration in configuration PR.
 	corsHeaders := map[string]string{
-		cors.AccessControlAllowOrigin:  "*",
-		cors.AccessControlAllowMethods: "GET, POST, PUT, DELETE, OPTIONS",
-		cors.AccessControlAllowHeaders: "Content-Type, Authorization",
+		cors.AccessControlAllowOrigin:  cfg.CORS.AllowOrigin,
+		cors.AccessControlAllowMethods: cfg.CORS.AllowMethods,
+		cors.AccessControlAllowHeaders: cfg.CORS.AllowHeaders,
 	}
 
 	srv := &http.Server{
-		Addr:         cfg.Listen,
+		Addr:         cfg.Server.Listen,
 		Handler:      cors.WithCorsMiddleware(corsHeaders, m),
 		TLSConfig:    am.TLSConfig(),
-		ReadTimeout:  time.Second * 10,
-		IdleTimeout:  time.Second * 10,
-		WriteTimeout: time.Second * 10,
+		ReadTimeout:  cfg.Server.Timeouts.Read,
+		IdleTimeout:  cfg.Server.Timeouts.Idle,
+		WriteTimeout: cfg.Server.Timeouts.Write,
 	}
 
-	if cfg.TLSCert != "" && cfg.TLSKey != "" {
+	if cfg.TLS.Cert != "" && cfg.TLS.Key != "" {
 		srv.TLSConfig = nil
 	}
 
@@ -178,11 +269,10 @@ func prepareRestAndRPCServer(log *slog.Logger, cfg config.Config, rpcProxyHandle
 }
 
 func prepareGRPCServer(log *slog.Logger, cfg config.Config, p *proxy.GRPCProxy) *http.Server {
-	// TODO: make this part of the configuration in configuration PR.
 	corsHeaders := map[string]string{
-		cors.AccessControlAllowOrigin:  "*",
-		cors.AccessControlAllowMethods: "GET, POST, PUT, DELETE, OPTIONS",
-		cors.AccessControlAllowHeaders: "Content-Type, Authorization",
+		cors.AccessControlAllowOrigin:  cfg.CORS.AllowOrigin,
+		cors.AccessControlAllowMethods: cfg.CORS.AllowMethods,
+		cors.AccessControlAllowHeaders: cfg.CORS.AllowHeaders,
 	}
 
 	mux := http.NewServeMux()
@@ -190,10 +280,10 @@ func prepareGRPCServer(log *slog.Logger, cfg config.Config, p *proxy.GRPCProxy) 
 
 	// Start HTTP/2.0 server.
 	grpcServer := &http.Server{
-		Addr:         cfg.ListenGRPC,
-		ReadTimeout:  time.Second * 10,
-		IdleTimeout:  time.Second * 10,
-		WriteTimeout: time.Second * 10,
+		Addr:         cfg.Server.ListenGRPC,
+		ReadTimeout:  cfg.Server.Timeouts.Read,
+		IdleTimeout:  cfg.Server.Timeouts.Idle,
+		WriteTimeout: cfg.Server.Timeouts.Write,
 		Handler:      h2c.NewHandler(mux, &http2.Server{}),
 	}
 

--- a/config.md
+++ b/config.md
@@ -11,6 +11,9 @@
  - `AKASH_PROXY_SEED_URL` (default: `https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/chain.json`) - Proxy seed URL to fetch for server updates.
  - `AKASH_PROXY_SEED_REFRESH_INTERVAL` (default: `5m`) - How frequently fetch SEED_URL for updates.
  - `AKASH_PROXY_CHAIN_ID` (default: `akashnet-2`) - Expected chain ID.
+ - `AKASH_PROXY_SEED_ADDITIONAL_NODES_RPC` (comma-separated) - List of additional RPC nodes.
+ - `AKASH_PROXY_SEED_ADDITIONAL_NODES_REST` (comma-separated) - List of additional REST nodes.
+ - `AKASH_PROXY_SEED_ADDITIONAL_NODES_GRPC` (comma-separated) - List of additional gRPC nodes.
  - `AKASH_PROXY_HEALTHY_THRESHOLD` (default: `10s`) - How slow on average a node needs to be to be marked as unhealthy.
  - `AKASH_PROXY_HEALTHY_ERROR_RATE_THRESHOLD` (default: `30`) - Percentage of request errors deemed acceptable.
  - `AKASH_PROXY_HEALTHY_ERROR_RATE_BUCKET_TIMEOUT` (default: `1m`) - How long in the past requests are considered to check for status codes.

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -1,6 +1,6 @@
 server:
   listen: ":8080"
-  listen_grpc: ":9091"
+  listen-grpc: ":9091"
   timeouts:
     read: "10s"
     write: "10s"
@@ -16,13 +16,17 @@ tls:
 seed:
   url: "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/chain.json"
   refresh_interval: "5m"
-  chain_id: "akashnet-2"
+  chain-id: "akashnet-2"
+  additional-nodes:
+    rpc: []
+    rest: []
+    grpc: []
 
 health:
-  healthy_threshold: "10s"
-  proxy_request_timeout: "15s"
+  healthy-threshold: "10s"
+  proxy-request-timeout: "15s"
 
 cors:
-  allow_origin: "*"
-  allow_methods: "GET, POST, PUT, DELETE, OPTIONS"
-  allow_headers: "Content-Type, Authorization"
+  allow-origin: "*"
+  allow-methods: "GET, POST, PUT, DELETE, OPTIONS"
+  allow-headers: "Content-Type, Authorization"

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -1,0 +1,28 @@
+server:
+  listen: ":8080"
+  listen_grpc: ":9091"
+  timeouts:
+    read: "10s"
+    write: "10s"
+    idle: "10s"
+
+tls:
+  autocert:
+    email: ""
+    hosts: []
+  cert: "./localhost.pem"
+  key: "./localhost-key.pem"
+
+seed:
+  url: "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/chain.json"
+  refresh_interval: "5m"
+  chain_id: "akashnet-2"
+
+health:
+  healthy_threshold: "10s"
+  proxy_request_timeout: "15s"
+
+cors:
+  allow_origin: "*"
+  allow_methods: "GET, POST, PUT, DELETE, OPTIONS"
+  allow_headers: "Content-Type, Authorization"

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/akash-network/rpc-proxy
 go 1.24.0
 
 require (
-	github.com/caarlos0/env/v11 v11.1.0
 	github.com/cometbft/cometbft v0.38.12
 	github.com/cosmos/cosmos-sdk v0.50.13
+	github.com/spf13/cobra v1.9.1
+	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.32.0
 	golang.org/x/net v0.34.0
@@ -124,9 +125,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
-	github.com/spf13/cobra v1.8.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/spf13/viper v1.19.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,6 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOF
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/bufbuild/protocompile v0.6.0 h1:Uu7WiSQ6Yj9DbkdnOe7U4mNKp58y9WDMKDn28/ZlunY=
 github.com/bufbuild/protocompile v0.6.0/go.mod h1:YNP35qEYoYGme7QMtz5SBCoN4kL4g12jTtjuzRNdjpE=
-github.com/caarlos0/env/v11 v11.1.0 h1:a5qZqieE9ZfzdvbbdhTalRrHT5vu/4V1/ad1Ka6frhI=
-github.com/caarlos0/env/v11 v11.1.0/go.mod h1:LwgkYk1kDvfGpHthrWWLof3Ny7PezzFwS4QrsJdHTMo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -141,7 +139,7 @@ github.com/cosmos/ics23/go v0.11.0/go.mod h1:A8OjxPE67hHST4Icw94hOxxFEJMBG031xIG
 github.com/cosmos/ledger-cosmos-go v0.14.0 h1:WfCHricT3rPbkPSVKRH+L4fQGKYHuGOK9Edpel8TYpE=
 github.com/cosmos/ledger-cosmos-go v0.14.0/go.mod h1:E07xCWSBl3mTGofZ2QnL4cIUzMbbGVyik84QYKbX3RA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
@@ -631,11 +629,12 @@ github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNo
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
-github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
-github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.19.0 h1:RWq5SEjt8o25SROyN3z2OrDB9l7RPd3lwTWU8EcEdcI=
 github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+Ntkg=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,11 @@ type SeedConfig struct {
 	URL             string        `mapstructure:"url"`
 	RefreshInterval time.Duration `mapstructure:"refresh-interval"`
 	ChainID         string        `mapstructure:"chain-id"`
+	AdditionalNodes struct {
+		RPC  []string `mapstructure:"rpc"`
+		REST []string `mapstructure:"rest"`
+		GRPC []string `mapstructure:"grpc"`
+	} `mapstructure:"additional-nodes"`
 }
 
 type HealthConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,63 +1,82 @@
 package config
 
 import (
+	"strings"
+	"sync"
 	"time"
 
-	"github.com/caarlos0/env/v11"
+	"github.com/spf13/viper"
 )
+
+var Replacer = strings.NewReplacer(".", "_", "-", "_")
+
+type ServerConfig struct {
+	Listen     string        `mapstructure:"listen"`
+	ListenGRPC string        `mapstructure:"listen-grpc"`
+	Timeouts   TimeoutConfig `mapstructure:"timeouts"`
+}
+
+type TimeoutConfig struct {
+	Read  time.Duration `mapstructure:"read"`
+	Write time.Duration `mapstructure:"write"`
+	Idle  time.Duration `mapstructure:"idle"`
+}
+
+type TLSConfig struct {
+	Autocert AutocertConfig `mapstructure:"autocert"`
+	Cert     string         `mapstructure:"cert"`
+	Key      string         `mapstructure:"key"`
+}
+
+type AutocertConfig struct {
+	Email string   `mapstructure:"email"`
+	Hosts []string `mapstructure:"hosts"`
+}
+
+type SeedConfig struct {
+	URL             string        `mapstructure:"url"`
+	RefreshInterval time.Duration `mapstructure:"refresh-interval"`
+	ChainID         string        `mapstructure:"chain-id"`
+}
+
+type HealthConfig struct {
+	HealthyThreshold    time.Duration `mapstructure:"healthy-threshold"`
+	ProxyRequestTimeout time.Duration `mapstructure:"proxy-request-timeout"`
+}
+
+type CORSConfig struct {
+	AllowOrigin  string `mapstructure:"allow-origin"`
+	AllowMethods string `mapstructure:"allow-methods"`
+	AllowHeaders string `mapstructure:"allow-headers"`
+}
 
 //go:generate go run github.com/g4s8/envdoc@latest -output ../../config.md -env-prefix AKASH_PROXY_ -types Config
 type Config struct {
-	// Address to listen to.
-	Listen string `env:"LISTEN" envDefault:":25567"`
-
-	// Address to listen to on GRPC proxy.
-	ListenGRPC string `env:"LISTEN_GRPC" envDefault:":9090"`
-
-	// Autocert account email.
-	AutocertEmail string `env:"AUTOCERT_EMAIL"`
-
-	// Autocert domains.
-	AutocertHosts []string `env:"AUTOCERT_HOSTS"`
-
-	// TLS certificate to use. If empty, will try to use autocert.
-	TLSCert string `env:"TLS_CERT"`
-
-	// TLS key to use. If empty, will try to use autocert.
-	TLSKey string `env:"TLS_KEY"`
-
-	// Proxy seed URL to fetch for server updates.
-	SeedURL string `env:"SEED_URL" envDefault:"https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/chain.json"`
-
-	// How frequently fetch SEED_URL for updates.
-	SeedRefreshInterval time.Duration `env:"SEED_REFRESH_INTERVAL" envDefault:"5m"`
-
-	// Expected chain ID.
-	ChainID string `env:"CHAIN_ID" envDefault:"akashnet-2"`
-
-	// How slow on average a node needs to be to be marked as unhealthy.
-	HealthyThreshold time.Duration `env:"HEALTHY_THRESHOLD" envDefault:"10s"`
-
-	// Percentage of request errors deemed acceptable.
-	HealthyErrorRateThreshold float64 `env:"HEALTHY_ERROR_RATE_THRESHOLD" envDefault:"30"`
-
-	// How long in the past requests are considered to check for status codes.
-	HealthyErrorRateBucketTimeout time.Duration `env:"HEALTHY_ERROR_RATE_BUCKET_TIMEOUT" envDefault:"1m"`
-
-	// Request timeout for a proxied request.
-	ProxyRequestTimeout time.Duration `env:"PROXY_REQUEST_TIMEOUT" envDefault:"15s"`
-
-	// How much chance (in %, 0-100), a node marked as unhealthy have to get a
-	// request again and recover.
-	UnhealthyServerRecoverChancePct int `env:"UNHEALTHY_SERVER_RECOVERY_CHANCE_PERCENT" envDefault:"1"`
+	Server ServerConfig `mapstructure:"server"`
+	TLS    TLSConfig    `mapstructure:"tls"`
+	Seed   SeedConfig   `mapstructure:"seed"`
+	Health HealthConfig `mapstructure:"health"`
+	CORS   CORSConfig   `mapstructure:"cors"`
 }
 
-func Must() Config {
-	cfg, err := env.ParseAsWithOptions[Config](env.Options{
-		Prefix: "AKASH_PROXY_",
-	})
-	if err != nil {
-		panic("could not get config: " + err.Error())
+var (
+	// cfg is the global config instance
+	cfg Config
+	mu  sync.Mutex
+)
+
+// Load reads the configuration from environment variables and unmarshals it into the Config struct.
+func Load(v *viper.Viper) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	return v.Unmarshal(&cfg)
+}
+
+// Must returns the current configuration or panics if it cannot be loaded.
+func Must(v *viper.Viper) Config {
+	if err := Load(v); err != nil {
+		panic("could not load config: " + err.Error())
 	}
 	return cfg
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,18 +1,139 @@
 package config
 
 import (
+	"os"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/spf13/viper"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestTest(t *testing.T) {
-	cfg := Must()
-	require.NotEmpty(t, cfg.Listen)
-	require.NotEmpty(t, cfg.SeedURL)
-	require.NotZero(t, cfg.SeedRefreshInterval)
-	require.NotZero(t, cfg.ChainID)
-	require.NotZero(t, cfg.HealthyThreshold)
-	require.NotZero(t, cfg.ProxyRequestTimeout)
-	require.NotZero(t, cfg.UnhealthyServerRecoverChancePct)
+var customTestConfig = Config{
+	Server: ServerConfig{
+		Listen:     ":8080",
+		ListenGRPC: ":9091",
+		Timeouts: TimeoutConfig{
+			Read:  15 * time.Second,
+			Write: 20 * time.Second,
+			Idle:  25 * time.Second,
+		},
+	},
+	TLS: TLSConfig{
+		Autocert: AutocertConfig{
+			Email: "test@example.com",
+			Hosts: []string{"example.com", "test.com"},
+		},
+		Cert: "/path/to/cert",
+		Key:  "/path/to/key",
+	},
+	Seed: SeedConfig{
+		URL:             "https://custom-seed-url.com",
+		RefreshInterval: 10 * time.Minute,
+		ChainID:         "custom-chain",
+	},
+	Health: HealthConfig{
+		HealthyThreshold:    20 * time.Second,
+		ProxyRequestTimeout: 30 * time.Second,
+	},
+	CORS: CORSConfig{
+		AllowOrigin:  "https://example.com",
+		AllowMethods: "GET,POST",
+		AllowHeaders: "Content-Type",
+	},
+}
+
+func TestEnvironmentVariables(t *testing.T) {
+	// Set custom environment variables
+	os.Setenv("AKASH_PROXY_SERVER_LISTEN", customTestConfig.Server.Listen)
+	os.Setenv("AKASH_PROXY_SERVER_LISTEN_GRPC", customTestConfig.Server.ListenGRPC)
+	os.Setenv("AKASH_PROXY_SERVER_TIMEOUTS_READ", customTestConfig.Server.Timeouts.Read.String())
+	os.Setenv("AKASH_PROXY_SERVER_TIMEOUTS_WRITE", customTestConfig.Server.Timeouts.Write.String())
+	os.Setenv("AKASH_PROXY_SERVER_TIMEOUTS_IDLE", customTestConfig.Server.Timeouts.Idle.String())
+	os.Setenv("AKASH_PROXY_TLS_AUTOCERT_EMAIL", customTestConfig.TLS.Autocert.Email)
+	os.Setenv("AKASH_PROXY_TLS_AUTOCERT_HOSTS", strings.Join(customTestConfig.TLS.Autocert.Hosts, ","))
+	os.Setenv("AKASH_PROXY_TLS_CERT", customTestConfig.TLS.Cert)
+	os.Setenv("AKASH_PROXY_TLS_KEY", customTestConfig.TLS.Key)
+	os.Setenv("AKASH_PROXY_SEED_URL", customTestConfig.Seed.URL)
+	os.Setenv("AKASH_PROXY_SEED_REFRESH_INTERVAL", customTestConfig.Seed.RefreshInterval.String())
+	os.Setenv("AKASH_PROXY_SEED_CHAIN_ID", customTestConfig.Seed.ChainID)
+	os.Setenv("AKASH_PROXY_HEALTH_HEALTHY_THRESHOLD", customTestConfig.Health.HealthyThreshold.String())
+	os.Setenv("AKASH_PROXY_HEALTH_PROXY_REQUEST_TIMEOUT", customTestConfig.Health.ProxyRequestTimeout.String())
+	os.Setenv("AKASH_PROXY_CORS_ALLOW_ORIGIN", customTestConfig.CORS.AllowOrigin)
+	os.Setenv("AKASH_PROXY_CORS_ALLOW_METHODS", customTestConfig.CORS.AllowMethods)
+	os.Setenv("AKASH_PROXY_CORS_ALLOW_HEADERS", customTestConfig.CORS.AllowHeaders)
+	defer clearAllEnvVars()
+
+	v := viper.New()
+	v.SetEnvPrefix("AKASH_PROXY")
+	v.SetEnvKeyReplacer(Replacer)
+	v.AutomaticEnv()
+
+	// Bind environment variables explicitly
+	v.BindEnv("server.listen")
+	v.BindEnv("server.listen-grpc")
+	v.BindEnv("server.timeouts.read")
+	v.BindEnv("server.timeouts.write")
+	v.BindEnv("server.timeouts.idle")
+	v.BindEnv("tls.autocert.email")
+	v.BindEnv("tls.autocert.hosts")
+	v.BindEnv("tls.cert")
+	v.BindEnv("tls.key")
+	v.BindEnv("seed.url")
+	v.BindEnv("seed.refresh-interval")
+	v.BindEnv("seed.chain-id")
+	v.BindEnv("health.healthy-threshold")
+	v.BindEnv("health.proxy-request-timeout")
+	v.BindEnv("cors.allow-origin")
+	v.BindEnv("cors.allow-methods")
+	v.BindEnv("cors.allow-headers")
+
+	assignedConfig := Must(v)
+
+	// Test all environment variable values
+	require.Equal(t, customTestConfig.Server.Listen, assignedConfig.Server.Listen)
+	require.Equal(t, customTestConfig.Server.ListenGRPC, assignedConfig.Server.ListenGRPC)
+	require.Equal(t, customTestConfig.Server.Timeouts.Read, assignedConfig.Server.Timeouts.Read)
+	require.Equal(t, customTestConfig.Server.Timeouts.Write, assignedConfig.Server.Timeouts.Write)
+	require.Equal(t, customTestConfig.Server.Timeouts.Idle, assignedConfig.Server.Timeouts.Idle)
+	require.Equal(t, customTestConfig.TLS.Autocert.Email, assignedConfig.TLS.Autocert.Email)
+	require.Equal(t, customTestConfig.TLS.Autocert.Hosts, assignedConfig.TLS.Autocert.Hosts)
+	require.Equal(t, customTestConfig.TLS.Cert, assignedConfig.TLS.Cert)
+	require.Equal(t, customTestConfig.TLS.Key, assignedConfig.TLS.Key)
+	require.Equal(t, customTestConfig.Seed.URL, assignedConfig.Seed.URL)
+	require.Equal(t, customTestConfig.Seed.RefreshInterval, assignedConfig.Seed.RefreshInterval)
+	require.Equal(t, customTestConfig.Seed.ChainID, assignedConfig.Seed.ChainID)
+	require.Equal(t, customTestConfig.Health.HealthyThreshold, assignedConfig.Health.HealthyThreshold)
+	require.Equal(t, customTestConfig.Health.ProxyRequestTimeout, assignedConfig.Health.ProxyRequestTimeout)
+	require.Equal(t, customTestConfig.CORS.AllowOrigin, assignedConfig.CORS.AllowOrigin)
+	require.Equal(t, customTestConfig.CORS.AllowMethods, assignedConfig.CORS.AllowMethods)
+	require.Equal(t, customTestConfig.CORS.AllowHeaders, assignedConfig.CORS.AllowHeaders)
+}
+
+func clearAllEnvVars() {
+	envVars := []string{
+		"AKASH_PROXY_SERVER_LISTEN",
+		"AKASH_PROXY_SERVER_LISTEN_GRPC",
+		"AKASH_PROXY_SERVER_TIMEOUTS_READ",
+		"AKASH_PROXY_SERVER_TIMEOUTS_WRITE",
+		"AKASH_PROXY_SERVER_TIMEOUTS_IDLE",
+		"AKASH_PROXY_TLS_AUTOCERT_EMAIL",
+		"AKASH_PROXY_TLS_AUTOCERT_HOSTS",
+		"AKASH_PROXY_TLS_CERT",
+		"AKASH_PROXY_TLS_KEY",
+		"AKASH_PROXY_SEED_URL",
+		"AKASH_PROXY_SEED_REFRESH_INTERVAL",
+		"AKASH_PROXY_SEED_CHAIN_ID",
+		"AKASH_PROXY_HEALTH_HEALTHY_THRESHOLD",
+		"AKASH_PROXY_HEALTH_PROXY_REQUEST_TIMEOUT",
+		"AKASH_PROXY_CORS_ALLOW_ORIGIN",
+		"AKASH_PROXY_CORS_ALLOW_METHODS",
+		"AKASH_PROXY_CORS_ALLOW_HEADERS",
+	}
+
+	for _, envVar := range envVars {
+		os.Unsetenv(envVar)
+	}
 }

--- a/internal/proxy/balancer_test.go
+++ b/internal/proxy/balancer_test.go
@@ -1,9 +1,6 @@
 package proxy
 
 import (
-	"github.com/akash-network/rpc-proxy/internal/avg"
-	"github.com/akash-network/rpc-proxy/internal/config"
-	"github.com/akash-network/rpc-proxy/internal/seed"
 	"log/slog"
 	"math"
 	"math/rand"
@@ -12,12 +9,14 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/akash-network/rpc-proxy/internal/avg"
+	"github.com/akash-network/rpc-proxy/internal/seed"
 )
 
 func TestRoundRobin_Next(t *testing.T) {
 	servers := []*Server{
 		{
-			cfg:          config.Config{},
 			name:         "a",
 			Url:          nil,
 			pings:        avg.Moving(1),
@@ -35,7 +34,6 @@ func TestRoundRobin_Next(t *testing.T) {
 			},
 		},
 		{
-			cfg:          config.Config{},
 			name:         "b",
 			Url:          nil,
 			pings:        avg.Moving(1),
@@ -81,7 +79,6 @@ func TestRoundRobin_Next(t *testing.T) {
 func TestLatencyBased_Next(t *testing.T) {
 	servers := []*Server{
 		{
-			cfg:          config.Config{},
 			name:         "a",
 			Url:          nil,
 			pings:        avg.Moving(1),
@@ -99,7 +96,6 @@ func TestLatencyBased_Next(t *testing.T) {
 			},
 		},
 		{
-			cfg:          config.Config{},
 			name:         "b",
 			Url:          nil,
 			pings:        avg.Moving(1),

--- a/internal/proxy/cors/cors_test.go
+++ b/internal/proxy/cors/cors_test.go
@@ -1,0 +1,133 @@
+package cors
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWithCorsMiddleware(t *testing.T) {
+	tests := []struct {
+		name            string
+		corsHeaders     map[string]string
+		requestMethod   string
+		expectedStatus  int
+		expectedHeaders map[string]string
+	}{
+		{
+			name: "regular request with CORS headers",
+			corsHeaders: map[string]string{
+				AccessControlAllowOrigin:  "*",
+				AccessControlAllowMethods: "GET, POST",
+				AccessControlAllowHeaders: "Content-Type",
+			},
+			requestMethod:  "GET",
+			expectedStatus: http.StatusOK,
+			expectedHeaders: map[string]string{
+				AccessControlAllowOrigin:  "*",
+				AccessControlAllowMethods: "GET, POST",
+				AccessControlAllowHeaders: "Content-Type",
+			},
+		},
+		{
+			name: "OPTIONS request with CORS headers",
+			corsHeaders: map[string]string{
+				AccessControlAllowOrigin:  "*",
+				AccessControlAllowMethods: "GET, POST",
+				AccessControlAllowHeaders: "Content-Type",
+			},
+			requestMethod:  "OPTIONS",
+			expectedStatus: http.StatusOK,
+			expectedHeaders: map[string]string{
+				AccessControlAllowOrigin:  "*",
+				AccessControlAllowMethods: "GET, POST",
+				AccessControlAllowHeaders: "Content-Type",
+			},
+		},
+		{
+			name:            "empty CORS headers",
+			corsHeaders:     map[string]string{},
+			requestMethod:   "GET",
+			expectedStatus:  http.StatusOK,
+			expectedHeaders: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			handler := WithCorsMiddleware(tt.corsHeaders, nextHandler)
+
+			req := httptest.NewRequest(tt.requestMethod, "http://example.com/foo", nil)
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+
+			for header, expectedValue := range tt.expectedHeaders {
+				got := w.Header().Get(header)
+				if got != expectedValue {
+					t.Errorf("expected header %s to be %q, got %q", header, expectedValue, got)
+				}
+			}
+		})
+	}
+}
+
+func TestDeleteCorsHeaders(t *testing.T) {
+	tests := []struct {
+		name           string
+		headers        map[string]string
+		expectedDelete bool
+	}{
+		{
+			name: "delete all supported CORS headers",
+			headers: map[string]string{
+				AccessControlAllowOrigin:  "*",
+				AccessControlAllowMethods: "GET, POST",
+				AccessControlAllowHeaders: "Content-Type",
+			},
+			expectedDelete: true,
+		},
+		{
+			name: "no supported CORS headers to delete",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+			expectedDelete: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := &http.Response{
+				Header: make(http.Header),
+			}
+			for k, v := range tt.headers {
+				response.Header.Set(k, v)
+			}
+
+			DeleteCorsHeaders(response)
+
+			for _, header := range SupportedHeaders {
+				if tt.expectedDelete && response.Header.Get(header) != "" {
+					t.Errorf("expected header %s to be deleted, but it still exists", header)
+				}
+			}
+
+			if !tt.expectedDelete {
+				for k, v := range tt.headers {
+					if response.Header.Get(k) != v {
+						t.Errorf("expected header %s to remain with value %s, got %s", k, v, response.Header.Get(k))
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/proxy/grpc.go
+++ b/internal/proxy/grpc.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 
-	"github.com/akash-network/rpc-proxy/internal/config"
 	"github.com/akash-network/rpc-proxy/internal/seed"
 )
 
@@ -21,13 +20,11 @@ type GRPCProxy struct {
 // configuration, logger, and a custom load balancer.
 func NewGRPCProxy(
 	ch chan seed.Seed,
-	cfg config.Config,
 	log *slog.Logger,
 	lb LoadBalancer,
 ) *GRPCProxy {
 	return &GRPCProxy{
 		Proxy: Proxy{
-			cfg: cfg,
 			ch:  ch,
 			log: log,
 			lb:  lb,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"context"
 	"fmt"
-	"github.com/akash-network/rpc-proxy/internal/proxy/cors"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
@@ -14,12 +13,14 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/akash-network/rpc-proxy/internal/proxy/cors"
+
 	"github.com/akash-network/rpc-proxy/internal/config"
 	"github.com/akash-network/rpc-proxy/internal/seed"
 )
 
 type Proxy struct {
-	cfg  config.Config
+	cfg  config.HealthConfig
 	log  *slog.Logger
 	init sync.Once
 	ch   chan seed.Seed
@@ -73,7 +74,6 @@ func (p *Proxy) doUpdate(providers []seed.Node) error {
 			srv, err := newServer(
 				provider.Provider,
 				target,
-				p.cfg,
 				p.log.With("server_address", provider.Address),
 				provider,
 			)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -27,12 +27,9 @@ func TestRPCProxy(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ch := make(chan seed.Seed, 1)
-	proxy := NewRPCProxy(ch, config.Config{
-		HealthyThreshold:                10 * time.Millisecond,
-		ProxyRequestTimeout:             time.Second,
-		UnhealthyServerRecoverChancePct: 1,
-		HealthyErrorRateThreshold:       10,
-		HealthyErrorRateBucketTimeout:   time.Second * 10,
+	proxy := NewRPCProxy(ch, config.HealthConfig{
+		HealthyThreshold:    10 * time.Millisecond,
+		ProxyRequestTimeout: time.Second,
 	}, logger, NewRoundRobin(logger))
 
 	proxy.Start(ctx)
@@ -63,12 +60,9 @@ func TestRestProxy(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ch := make(chan seed.Seed, 1)
-	proxy := NewRestProxy(ch, config.Config{
-		HealthyThreshold:                10 * time.Millisecond,
-		ProxyRequestTimeout:             time.Second,
-		UnhealthyServerRecoverChancePct: 1,
-		HealthyErrorRateThreshold:       10,
-		HealthyErrorRateBucketTimeout:   time.Second * 10,
+	proxy := NewRestProxy(ch, config.HealthConfig{
+		HealthyThreshold:    10 * time.Millisecond,
+		ProxyRequestTimeout: time.Second,
 	}, logger, NewRoundRobin(logger))
 
 	proxy.Start(ctx)
@@ -300,7 +294,7 @@ func TestDoUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Proxy{
-				cfg:     config.Config{},
+				cfg:     config.HealthConfig{},
 				log:     slog.Default(),
 				servers: []*Server{},
 				lb:      &MockLoadBalancer{},

--- a/internal/proxy/rest.go
+++ b/internal/proxy/rest.go
@@ -21,7 +21,7 @@ type RestProxy struct {
 // configuration, logger, and load balancer.
 func NewRestProxy(
 	ch chan seed.Seed,
-	cfg config.Config,
+	cfg config.HealthConfig,
 	log *slog.Logger,
 	lb LoadBalancer,
 ) *RestProxy {

--- a/internal/proxy/rpc.go
+++ b/internal/proxy/rpc.go
@@ -21,7 +21,7 @@ type RPCProxy struct {
 // seed channel, logger, and a load balancer.
 func NewRPCProxy(
 	ch chan seed.Seed,
-	cfg config.Config,
+	cfg config.HealthConfig,
 	log *slog.Logger,
 	lb LoadBalancer,
 ) *RPCProxy {

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -8,18 +8,16 @@ import (
 	"github.com/akash-network/rpc-proxy/internal/seed"
 
 	"github.com/akash-network/rpc-proxy/internal/avg"
-	"github.com/akash-network/rpc-proxy/internal/config"
 	"github.com/akash-network/rpc-proxy/internal/ttlslice"
 )
 
 // TODO: Replace these stats with prometheus metrics server.
 
-func newServer(name string, target *url.URL, cfg config.Config, log *slog.Logger, node seed.Node) (*Server, error) {
+func newServer(name string, target *url.URL, log *slog.Logger, node seed.Node) (*Server, error) {
 	return &Server{
 		name:      name,
 		Url:       target,
 		pings:     avg.Moving(50),
-		cfg:       cfg,
 		successes: ttlslice.New[int](),
 		failures:  ttlslice.New[int](),
 		log:       log,
@@ -28,7 +26,6 @@ func newServer(name string, target *url.URL, cfg config.Config, log *slog.Logger
 }
 
 type Server struct {
-	cfg          config.Config
 	name         string
 	Url          *url.URL
 	pings        *avg.MovingAverage

--- a/internal/seed/config.go
+++ b/internal/seed/config.go
@@ -12,4 +12,11 @@ type Config struct {
 
 	// ChainID is the ID of the chain.
 	ChainID string
+
+	// AdditionalNodes contains additional configured nodes
+	AdditionalNodes struct {
+		RPC  []string
+		REST []string
+		GRPC []string
+	}
 }

--- a/internal/seed/seed.go
+++ b/internal/seed/seed.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+const FallbackNodeProvider = "Unknown"
+
 type Seed struct {
 	Status  string `json:"status"`
 	ChainID string `json:"chain_id"`
@@ -127,6 +129,29 @@ func (s *Seeder) fetch(ctx context.Context, log *slog.Logger, url string) (Seed,
 		return seed, fmt.Errorf("parse seed: %w", err)
 	}
 
+	// Add manual nodes
+	for _, addr := range s.cfg.AdditionalNodes.RPC {
+		seed.APIs.RPC = append(seed.APIs.RPC, Node{
+			Address:  addr,
+			Provider: FallbackNodeProvider,
+		})
+	}
+
+	for _, addr := range s.cfg.AdditionalNodes.REST {
+		seed.APIs.Rest = append(seed.APIs.Rest, Node{
+			Address:  addr,
+			Provider: FallbackNodeProvider,
+		})
+	}
+
+	for _, addr := range s.cfg.AdditionalNodes.GRPC {
+		seed.APIs.GRPC = append(seed.APIs.GRPC, Node{
+			Address:  addr,
+			Provider: FallbackNodeProvider,
+		})
+	}
+
+	// Probe all nodes (both from seed URL and manual)
 	for i, rpcProxy := range seed.APIs.RPC {
 		status, err := s.rpcProbe.Probe(ctx, rpcProxy)
 		if err != nil {


### PR DESCRIPTION
This PR adds support for `viper` configurations and implements a small CLI using `cobra` to initiate the proxy.

## CLI documentation
```
Akash Proxy provides load balancing and automatic failover for Akash network RPC, gRPC and REST nodes.

Usage:
  akash-proxy [flags]

Flags:
  -c, --config string                           config file (default is $HOME/.akash-proxy/config.yaml)
      --cors.allow-headers string               CORS allowed headers (default "Content-Type, Authorization")
      --cors.allow-methods string               CORS allowed methods (default "GET, POST, PUT, DELETE, OPTIONS")
      --cors.allow-origin string                CORS allowed origin (default "*")
      --health.healthy-threshold duration       Response time threshold for healthy nodes (default 10s)
      --health.proxy-request-timeout duration   Timeout for proxied requests (default 15s)
  -h, --help                                    help for akash-proxy
      --seed.additional-nodes.grpc strings      Comma-separated list of additional gRPC nodes
      --seed.additional-nodes.rest strings      Comma-separated list of additional REST nodes
      --seed.additional-nodes.rpc strings       Comma-separated list of additional RPC nodes
      --seed.chain-id string                    Expected chain ID (default "akashnet-2")
      --seed.refresh-interval duration          How often to refresh node list (default 5m0s)
      --seed.url string                         URL to fetch initial node list (default "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/chain.json")
      --server.listen string                    Address to listen on for HTTP REST & RPC requests (default ":25567")
      --server.listen-grpc string               Address to listen on for gRPC requests (default ":9090")
      --server.timeouts.idle duration           Server idle timeout (default 10s)
      --server.timeouts.read duration           Server read timeout (default 10s)
      --server.timeouts.write duration          Server write timeout (default 10s)
      --tls.autocert.email string               Email for Let's Encrypt certificates
      --tls.autocert.hosts strings              Comma-separated list of domains for Let's Encrypt
      --tls.cert string                         Path to TLS certificate file
      --tls.key string                          Path to TLS private key file
```

## Example usages

```bash
go run cmd/main.go --config=./config/local.yaml
go run cmd/main.go --config=./config/local.yaml --seed.additional-nodes.grpc=my-grpc-node.com:12345
AKASH_PROXY_TLS_KEY=localhost-key.pem AKASH_PROXY_TLS_CERT=localhost.pem AKASH_PROXY_SEED_REFRESH_INTERVAL=30s go run cmd/main.go --server.listen=:8080
```