### PR TITLE
feat: add a sticky session latency-based load balancer

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -165,9 +165,11 @@ func runProxy(cfg config.Config) {
 		},
 	}
 	seeder := seed.New(seederCfg, log, rpcListener, restListener, grpcListener)
-	rpcProxyHandler := proxy.NewRPCProxy(rpcListener, cfg.Health, log, proxy.NewStickyLatencyBased(log, 6*time.Second))
-	restProxyHandler := proxy.NewRestProxy(restListener, cfg.Health, log, proxy.NewStickyLatencyBased(log, 6*time.Second))
-	grpcProxyHandler := proxy.NewGRPCProxy(grpcListener, log, proxy.NewStickyLatencyBased(log, 6*time.Second))
+
+	blockTime := 6 * time.Second
+	rpcProxyHandler := proxy.NewRPCProxy(rpcListener, cfg.Health, log, proxy.NewStickyLatencyBased(log, blockTime))
+	restProxyHandler := proxy.NewRestProxy(restListener, cfg.Health, log, proxy.NewStickyLatencyBased(log, blockTime))
+	grpcProxyHandler := proxy.NewGRPCProxy(grpcListener, log, proxy.NewStickyLatencyBased(log, blockTime))
 
 	ctx, proxyCtxCancel := context.WithCancel(context.Background())
 	defer proxyCtxCancel()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -165,9 +165,9 @@ func runProxy(cfg config.Config) {
 		},
 	}
 	seeder := seed.New(seederCfg, log, rpcListener, restListener, grpcListener)
-	rpcProxyHandler := proxy.NewRPCProxy(rpcListener, cfg.Health, log, proxy.NewLatencyBased(log))
-	restProxyHandler := proxy.NewRestProxy(restListener, cfg.Health, log, proxy.NewLatencyBased(log))
-	grpcProxyHandler := proxy.NewGRPCProxy(grpcListener, log, proxy.NewLatencyBased(log))
+	rpcProxyHandler := proxy.NewRPCProxy(rpcListener, cfg.Health, log, proxy.NewStickyLatencyBased(log, 6*time.Second))
+	restProxyHandler := proxy.NewRestProxy(restListener, cfg.Health, log, proxy.NewStickyLatencyBased(log, 6*time.Second))
+	grpcProxyHandler := proxy.NewGRPCProxy(grpcListener, log, proxy.NewStickyLatencyBased(log, 6*time.Second))
 
 	ctx, proxyCtxCancel := context.WithCancel(context.Background())
 	defer proxyCtxCancel()
@@ -264,7 +264,7 @@ func runProxy(cfg config.Config) {
 }
 
 func main() {
-	var v = viper.New()
+	v := viper.New()
 
 	if err := NewRootCmd(v).Execute(); err != nil {
 		log.Fatalf("failed to execute command: %v", err)

--- a/internal/proxy/balancer.go
+++ b/internal/proxy/balancer.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"log/slog"
 	"math/rand"
+	"net/http"
 	"sync"
 	"time"
 )
@@ -11,6 +12,9 @@ import (
 // used as toleration when comparing floats.
 const epsilon = 1e-9
 
+// ProxyKeyHeader is the HTTP header used for sticky session identification
+const ProxyKeyHeader = "X-PROXY-KEY"
+
 // LoadBalancer is an interface for load balancing algorithms. It provides
 // methods to update the list of available servers and to select the next
 // server to be used.
@@ -18,7 +22,7 @@ type LoadBalancer interface {
 	// Update updates the list of available servers.
 	Update([]*Server)
 	// Next returns the next server to be used based on the load balancing algorithm.
-	Next() *Server
+	Next(*http.Request) *Server
 }
 
 // RoundRobin is a simple load balancer that distributes incoming requests
@@ -43,7 +47,7 @@ func NewRoundRobin(log *slog.Logger) *RoundRobin {
 
 // Next returns the next server to be used based on the round-robin algorithm.
 // If the selected server is unhealthy, it will recursively try the next server.
-func (rr *RoundRobin) Next() *Server {
+func (rr *RoundRobin) Next(_ *http.Request) *Server {
 	rr.mu.Lock()
 	if len(rr.servers) == 0 {
 		return nil
@@ -56,7 +60,7 @@ func (rr *RoundRobin) Next() *Server {
 		return server
 	}
 	rr.log.Warn("server is unhealthy, trying next", "name", server.name)
-	return rr.Next()
+	return rr.Next(nil)
 }
 
 // Update updates the list of available servers.
@@ -104,7 +108,7 @@ func NewLatencyBased(log *slog.Logger) *LatencyBased {
 // The random number will fall into one of these ranges, effectively selecting
 // a server based on its latency rate. This approach works regardless of the order of
 // the servers, so there's no need to sort them based on latency or rate.
-func (rr *LatencyBased) Next() *Server {
+func (rr *LatencyBased) Next(_ *http.Request) *Server {
 	rr.mu.Lock()
 	defer rr.mu.Unlock()
 
@@ -157,5 +161,151 @@ func (rr *LatencyBased) Update(servers []*Server) {
 	// Normalize the rates to ensure they sum to 1.0
 	for i := range servers {
 		rr.servers[i].Rate /= totalInverse
+	}
+}
+
+// StickyLatencyBased is a load balancer that combines session affinity with latency-based routing.
+// It embeds LatencyBased to reuse latency calculation and server management functionality,
+// while adding session stickiness using industry-standard headers and cookies.
+// Warning: This load balancer type is not effective if running alongside other replicas as
+// the state is not shared between replicas.
+type StickyLatencyBased struct {
+	// LatencyBased provides the core latency-based selection functionality
+	*LatencyBased
+	// sessionMap maps session identifiers to server references for sticky sessions.
+	sessionMap map[string]*Server
+	// sessionMu is a separate mutex for session-specific operations to avoid lock contention
+	sessionMu sync.RWMutex
+	// sessionTimeout defines how long sessions are kept in memory.
+	sessionTimeout time.Duration
+	// sessionCleanupTicker periodically cleans up expired sessions.
+	sessionCleanupTicker *time.Ticker
+	// sessionTimestamps tracks when sessions were last accessed.
+	sessionTimestamps map[string]time.Time
+}
+
+// NewStickyLatencyBased returns a new StickyLatencyBased load balancer instance.
+// It embeds a LatencyBased load balancer and adds session management functionality.
+func NewStickyLatencyBased(log *slog.Logger, sessionTimeout time.Duration) *StickyLatencyBased {
+	if sessionTimeout == 0 {
+		sessionTimeout = 30 * time.Minute // Default session timeout
+	}
+
+	slb := &StickyLatencyBased{
+		LatencyBased:      NewLatencyBased(log),
+		sessionMap:        make(map[string]*Server),
+		sessionTimestamps: make(map[string]time.Time),
+		sessionTimeout:    sessionTimeout,
+	}
+
+	// Start cleanup routine for expired sessions
+	slb.sessionCleanupTicker = time.NewTicker(5 * time.Minute)
+	go slb.cleanupExpiredSessions()
+
+	return slb
+}
+
+// Next returns the next server based on session affinity and latency.
+// It first checks for existing session identifiers in headers or cookies,
+// then falls back to the embedded LatencyBased selection for new sessions.
+func (slb *StickyLatencyBased) Next(req *http.Request) *Server {
+	if req == nil {
+		slb.log.Warn("provided request is nil")
+		return slb.LatencyBased.Next(nil)
+	}
+
+	slb.LatencyBased.mu.Lock()
+	if len(slb.LatencyBased.servers) == 0 {
+		slb.LatencyBased.mu.Unlock()
+		return nil
+	}
+	slb.LatencyBased.mu.Unlock()
+
+	sessionID := slb.extractSessionID(req)
+
+	if sessionID != "" {
+		slb.sessionMu.RLock()
+		if server, exists := slb.sessionMap[sessionID]; exists {
+			// Check if session has timed out (cache miss scenario)
+			lastAccessed := slb.sessionTimestamps[sessionID]
+			if time.Since(lastAccessed) > slb.sessionTimeout {
+				slb.sessionMu.RUnlock()
+
+				// Session timed out, clean it up
+				slb.sessionMu.Lock()
+				delete(slb.sessionMap, sessionID)
+				delete(slb.sessionTimestamps, sessionID)
+				slb.sessionMu.Unlock()
+
+				slb.log.Info("session timed out, removed",
+					"session_id", sessionID,
+					"server", server.name,
+					"last_accessed", lastAccessed)
+			} else {
+				// Session is valid (cache hit scenario)
+				slb.sessionMu.RUnlock()
+
+				// Update session timestamp
+				slb.sessionMu.Lock()
+				slb.sessionTimestamps[sessionID] = time.Now()
+				slb.sessionMu.Unlock()
+				return server
+			}
+		} else {
+			slb.sessionMu.RUnlock()
+		}
+	}
+
+	// No existing session or unhealthy server, use embedded LatencyBased selection
+	server := slb.LatencyBased.Next(req)
+
+	if server != nil && sessionID != "" {
+		// Create new session mapping
+		slb.sessionMu.Lock()
+		slb.sessionMap[sessionID] = server
+		slb.sessionTimestamps[sessionID] = time.Now()
+		slb.sessionMu.Unlock()
+
+		slb.log.Debug("created new sticky session",
+			"session_id", sessionID,
+			"server", server.name)
+	}
+
+	return server
+}
+
+// extractSessionID extracts session identifier from HTTP request.
+// It only checks for the X-PROXY-KEY header. If not provided, returns empty string
+// which will cause the load balancer to use normal latency-based selection.
+func (slb *StickyLatencyBased) extractSessionID(req *http.Request) string {
+	return req.Header.Get(ProxyKeyHeader)
+}
+
+// Update updates the list of available servers using the embedded LatencyBased functionality
+// and cleans up session mappings for servers that no longer exist.
+func (slb *StickyLatencyBased) Update(servers []*Server) {
+	slb.LatencyBased.Update(servers)
+}
+
+// cleanupExpiredSessions runs in a background goroutine to clean up expired sessions
+func (slb *StickyLatencyBased) cleanupExpiredSessions() {
+	for range slb.sessionCleanupTicker.C {
+		slb.sessionMu.Lock()
+		now := time.Now()
+		for sessionID, timestamp := range slb.sessionTimestamps {
+			if now.Sub(timestamp) > slb.sessionTimeout {
+				delete(slb.sessionMap, sessionID)
+				delete(slb.sessionTimestamps, sessionID)
+				slb.log.Debug("cleaned up expired session", "session_id", sessionID)
+			}
+		}
+		slb.sessionMu.Unlock()
+	}
+}
+
+// Stop stops the cleanup ticker and releases resources
+func (slb *StickyLatencyBased) Stop() {
+	if slb.sessionCleanupTicker != nil {
+		slb.sessionCleanupTicker.Stop()
 	}
 }

--- a/internal/proxy/balancer.go
+++ b/internal/proxy/balancer.go
@@ -240,11 +240,16 @@ func (slb *StickyLatencyBased) Next(req *http.Request) *Server {
 					"last_accessed", lastAccessed)
 			} else {
 				slb.sessionMu.RUnlock()
-
+				if server != nil && server.Healthy() { // serve only healthy cached servers.
+					slb.sessionMu.Lock()
+					slb.sessionTimestamps[sessionID] = time.Now()
+					slb.sessionMu.Unlock()
+					return server
+				}
 				slb.sessionMu.Lock()
-				slb.sessionTimestamps[sessionID] = time.Now()
+				delete(slb.sessionMap, sessionID)
+				delete(slb.sessionTimestamps, sessionID)
 				slb.sessionMu.Unlock()
-				return server
 			}
 		} else {
 			slb.sessionMu.RUnlock()
@@ -278,6 +283,36 @@ func (slb *StickyLatencyBased) extractSessionID(req *http.Request) string {
 // and cleans up session mappings for servers that no longer exist.
 func (slb *StickyLatencyBased) Update(servers []*Server) {
 	slb.LatencyBased.Update(servers)
+	slb.pruneInvalidSessions(servers)
+}
+
+// pruneInvalidSessions removes session mappings for servers that no longer exist
+// in the provided server list.
+func (slb *StickyLatencyBased) pruneInvalidSessions(servers []*Server) {
+	// Create a lookup map from the input servers for O(1) lookups
+	serverExists := make(map[string]bool, len(servers))
+	for _, s := range servers {
+		if s != nil {
+			serverExists[s.name] = true
+		}
+	}
+
+	slb.sessionMu.Lock()
+	defer slb.sessionMu.Unlock()
+
+	for sid, srv := range slb.sessionMap {
+		if srv == nil || !serverExists[srv.name] {
+			delete(slb.sessionMap, sid)
+			delete(slb.sessionTimestamps, sid)
+			if srv != nil {
+				slb.log.Debug(
+					"removed sticky session for deleted server",
+					"session_id", sid,
+					"server", srv.name,
+				)
+			}
+		}
+	}
 }
 
 // cleanupExpiredSessions runs in a background goroutine to clean up expired sessions

--- a/internal/proxy/balancer.go
+++ b/internal/proxy/balancer.go
@@ -198,7 +198,6 @@ func NewStickyLatencyBased(log *slog.Logger, sessionTimeout time.Duration) *Stic
 		sessionTimeout:    sessionTimeout,
 	}
 
-	// Start cleanup routine for expired sessions
 	slb.sessionCleanupTicker = time.NewTicker(5 * time.Minute)
 	go slb.cleanupExpiredSessions()
 
@@ -226,12 +225,10 @@ func (slb *StickyLatencyBased) Next(req *http.Request) *Server {
 	if sessionID != "" {
 		slb.sessionMu.RLock()
 		if server, exists := slb.sessionMap[sessionID]; exists {
-			// Check if session has timed out (cache miss scenario)
 			lastAccessed := slb.sessionTimestamps[sessionID]
 			if time.Since(lastAccessed) > slb.sessionTimeout {
 				slb.sessionMu.RUnlock()
 
-				// Session timed out, clean it up
 				slb.sessionMu.Lock()
 				delete(slb.sessionMap, sessionID)
 				delete(slb.sessionTimestamps, sessionID)
@@ -242,10 +239,8 @@ func (slb *StickyLatencyBased) Next(req *http.Request) *Server {
 					"server", server.name,
 					"last_accessed", lastAccessed)
 			} else {
-				// Session is valid (cache hit scenario)
 				slb.sessionMu.RUnlock()
 
-				// Update session timestamp
 				slb.sessionMu.Lock()
 				slb.sessionTimestamps[sessionID] = time.Now()
 				slb.sessionMu.Unlock()
@@ -256,11 +251,9 @@ func (slb *StickyLatencyBased) Next(req *http.Request) *Server {
 		}
 	}
 
-	// No existing session or unhealthy server, use embedded LatencyBased selection
 	server := slb.LatencyBased.Next(req)
 
 	if server != nil && sessionID != "" {
-		// Create new session mapping
 		slb.sessionMu.Lock()
 		slb.sessionMap[sessionID] = server
 		slb.sessionTimestamps[sessionID] = time.Now()

--- a/internal/proxy/balancer.go
+++ b/internal/proxy/balancer.go
@@ -236,7 +236,6 @@ func (slb *StickyLatencyBased) NextServer(req *http.Request) *Server {
 
 				slb.log.Info("session timed out, removed",
 					"session_id", sessionID,
-					"server", server.name,
 					"last_accessed", lastAccessed)
 			} else {
 				slb.sessionMu.RUnlock()

--- a/internal/proxy/balancer.go
+++ b/internal/proxy/balancer.go
@@ -21,8 +21,8 @@ const ProxyKeyHeader = "X-PROXY-KEY"
 type LoadBalancer interface {
 	// Update updates the list of available servers.
 	Update([]*Server)
-	// Next returns the next server to be used based on the load balancing algorithm.
-	Next(*http.Request) *Server
+	// NextServer returns the next server to be used based on the load balancing algorithm.
+	NextServer(*http.Request) *Server
 }
 
 // RoundRobin is a simple load balancer that distributes incoming requests
@@ -45,9 +45,9 @@ func NewRoundRobin(log *slog.Logger) *RoundRobin {
 	}
 }
 
-// Next returns the next server to be used based on the round-robin algorithm.
+// NextServer returns the next server to be used based on the round-robin algorithm.
 // If the selected server is unhealthy, it will recursively try the next server.
-func (rr *RoundRobin) Next(_ *http.Request) *Server {
+func (rr *RoundRobin) NextServer(r *http.Request) *Server {
 	rr.mu.Lock()
 	if len(rr.servers) == 0 {
 		return nil
@@ -60,7 +60,7 @@ func (rr *RoundRobin) Next(_ *http.Request) *Server {
 		return server
 	}
 	rr.log.Warn("server is unhealthy, trying next", "name", server.name)
-	return rr.Next(nil)
+	return rr.NextServer(r)
 }
 
 // Update updates the list of available servers.
@@ -100,7 +100,7 @@ func NewLatencyBased(log *slog.Logger) *LatencyBased {
 	}
 }
 
-// Next returns the next server based on the weighted random selection,
+// NextServer returns the next server based on the weighted random selection,
 // where the weight is determined by the latency Rate of each server. The cumulative
 // approach is used to select a server, effectively creating a "range" for each
 // server in the interval [0, 1]. For example, if the rates are [0.5, 0.3, 0.2],
@@ -108,7 +108,7 @@ func NewLatencyBased(log *slog.Logger) *LatencyBased {
 // The random number will fall into one of these ranges, effectively selecting
 // a server based on its latency rate. This approach works regardless of the order of
 // the servers, so there's no need to sort them based on latency or rate.
-func (rr *LatencyBased) Next(_ *http.Request) *Server {
+func (rr *LatencyBased) NextServer(_ *http.Request) *Server {
 	rr.mu.Lock()
 	defer rr.mu.Unlock()
 
@@ -204,13 +204,13 @@ func NewStickyLatencyBased(log *slog.Logger, sessionTimeout time.Duration) *Stic
 	return slb
 }
 
-// Next returns the next server based on session affinity and latency.
+// NextServer returns the next server based on session affinity and latency.
 // It first checks for existing session identifiers in headers or cookies,
 // then falls back to the embedded LatencyBased selection for new sessions.
-func (slb *StickyLatencyBased) Next(req *http.Request) *Server {
+func (slb *StickyLatencyBased) NextServer(req *http.Request) *Server {
 	if req == nil {
 		slb.log.Warn("provided request is nil")
-		return slb.LatencyBased.Next(nil)
+		return slb.LatencyBased.NextServer(req)
 	}
 
 	slb.LatencyBased.mu.Lock()
@@ -256,7 +256,7 @@ func (slb *StickyLatencyBased) Next(req *http.Request) *Server {
 		}
 	}
 
-	server := slb.LatencyBased.Next(req)
+	server := slb.LatencyBased.NextServer(req)
 
 	if server != nil && sessionID != "" {
 		slb.sessionMu.Lock()

--- a/internal/proxy/balancer_test.go
+++ b/internal/proxy/balancer_test.go
@@ -1,9 +1,12 @@
 package proxy
 
 import (
+	"fmt"
 	"log/slog"
 	"math"
 	"math/rand"
+	"net/http"
+	"net/url"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -64,7 +67,7 @@ func TestRoundRobin_Next(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < n; j++ {
 				t.Logf("goroutine %d: ", id)
-				lb.Next()
+				lb.Next(nil)
 			}
 		}(i)
 	}
@@ -139,7 +142,7 @@ func TestLatencyBased_Next(t *testing.T) {
 		go func(id int) {
 			for j := 0; j < n; j++ {
 				t.Logf("goroutine %d: ", id)
-				queue <- lb.Next()
+				queue <- lb.Next(nil)
 			}
 			wg.Done()
 		}(i)
@@ -169,4 +172,376 @@ func TestLatencyBased_Next(t *testing.T) {
 	if selectedServers["b"] != 1 {
 		t.Errorf("expected server \"b\" to be selected 1 time, got selected %d times", selectedServers["b"])
 	}
+}
+
+func TestStickyLatencyBased_SessionAffinity(t *testing.T) {
+	servers := []*Server{
+		createTestServer("server1", 10*time.Millisecond),
+		createTestServer("server2", 20*time.Millisecond),
+		createTestServer("server3", 30*time.Millisecond),
+	}
+
+	lb := NewStickyLatencyBased(slog.New(slog.NewTextHandler(os.Stdout, nil)), 5*time.Minute)
+	defer lb.Stop()
+	lb.Update(servers)
+
+	// Test X-PROXY-KEY header
+	req1 := createTestRequest()
+	req1.Header.Set(ProxyKeyHeader, "session123")
+
+	// First request should select a server (using weighted random selection)
+	server1 := lb.Next(req1)
+	if server1 == nil {
+		t.Fatal("expected a server to be selected")
+	}
+	// Note: Due to weighted random selection, any healthy server could be selected
+
+	// Second request with same session ID should go to same server
+	req2 := createTestRequest()
+	req2.Header.Set(ProxyKeyHeader, "session123")
+	server2 := lb.Next(req2)
+
+	if server2.name != server1.name {
+		t.Errorf("expected same server %s, got %s", server1.name, server2.name)
+	}
+
+	// Different session ID should potentially select different server (but likely same due to latency)
+	req3 := createTestRequest()
+	req3.Header.Set(ProxyKeyHeader, "session456")
+	server3 := lb.Next(req3)
+
+	if server3 == nil {
+		t.Fatal("expected a server to be selected")
+	}
+}
+
+func TestStickyLatencyBased_NoProxyKey(t *testing.T) {
+	servers := []*Server{
+		createTestServer("server1", 10*time.Millisecond),
+		createTestServer("server2", 20*time.Millisecond),
+		createTestServer("server3", 30*time.Millisecond),
+	}
+
+	lb := NewStickyLatencyBased(slog.New(slog.NewTextHandler(os.Stdout, nil)), 5*time.Minute)
+	defer lb.Stop()
+	lb.Update(servers)
+
+	// Test requests without X-PROXY-KEY header should use normal latency-based selection
+	req1 := createTestRequest()
+	// No X-PROXY-KEY header set
+
+	server1 := lb.Next(req1)
+	if server1 == nil {
+		t.Fatal("expected a server to be selected")
+	}
+	// Should select a healthy server (using weighted random selection)
+	if !server1.Healthy() {
+		t.Errorf("expected a healthy server, got unhealthy server %s", server1.name)
+	}
+
+	// Second request without X-PROXY-KEY should also use latency-based selection
+	req2 := createTestRequest()
+	server2 := lb.Next(req2)
+
+	if server2 == nil {
+		t.Fatal("expected a server to be selected")
+	}
+	if !server2.Healthy() {
+		t.Errorf("expected a healthy server, got unhealthy server %s", server2.name)
+	}
+}
+
+func TestStickyLatencyBased_SessionPersistence(t *testing.T) {
+	servers := []*Server{
+		createTestServer("server1", 10*time.Millisecond),
+		createTestServer("server2", 20*time.Millisecond),
+	}
+
+	lb := NewStickyLatencyBased(slog.New(slog.NewTextHandler(os.Stdout, nil)), 5*time.Minute)
+	defer lb.Stop()
+	lb.Update(servers)
+
+	// Create session with first server
+	req1 := createTestRequest()
+	req1.Header.Set(ProxyKeyHeader, "session123")
+
+	server1 := lb.Next(req1)
+	if server1 == nil {
+		t.Fatal("expected a server to be selected")
+	}
+
+	// Second request with same session should go to same server
+	req2 := createTestRequest()
+	req2.Header.Set(ProxyKeyHeader, "session123")
+	server2 := lb.Next(req2)
+
+	if server2 == nil {
+		t.Fatal("expected a server to be selected")
+	}
+	if server2.name != server1.name {
+		t.Errorf("expected same server %s, got %s", server1.name, server2.name)
+	}
+}
+
+func TestStickyLatencyBased_SessionTimeout(t *testing.T) {
+	servers := []*Server{
+		createTestServer("server1", 10*time.Millisecond),
+		createTestServer("server2", 20*time.Millisecond),
+	}
+
+	// Short session timeout for testing
+	lb := NewStickyLatencyBased(slog.New(slog.NewTextHandler(os.Stdout, nil)), 50*time.Millisecond)
+	defer lb.Stop()
+
+	// Override the cleanup ticker with a faster one for testing
+	lb.sessionCleanupTicker.Stop()
+	lb.sessionCleanupTicker = time.NewTicker(25 * time.Millisecond)
+	go lb.cleanupExpiredSessions()
+
+	lb.Update(servers)
+
+	// Create session
+	req1 := createTestRequest()
+	req1.Header.Set(ProxyKeyHeader, "session123")
+
+	server1 := lb.Next(req1)
+	if server1 == nil {
+		t.Fatal("expected a server to be selected")
+	}
+
+	// Verify session exists
+	lb.sessionMu.RLock()
+	_, exists := lb.sessionMap["session123"]
+	lb.sessionMu.RUnlock()
+	if !exists {
+		t.Error("session should exist")
+	}
+
+	// Wait for session to expire and cleanup to run
+	time.Sleep(150 * time.Millisecond)
+
+	// Session should be cleaned up
+	lb.sessionMu.RLock()
+	_, exists = lb.sessionMap["session123"]
+	lb.sessionMu.RUnlock()
+	if exists {
+		t.Error("session should have been cleaned up")
+	}
+}
+
+func TestStickyLatencyBased_CacheHitMiss(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	lb := NewStickyLatencyBased(log, 100*time.Millisecond) // Short timeout for testing
+	defer lb.Stop()
+
+	servers := []*Server{
+		createTestServer("server1", 10*time.Millisecond),
+		createTestServer("server2", 20*time.Millisecond),
+	}
+	lb.Update(servers)
+
+	req, _ := http.NewRequest("GET", "/test", nil)
+	req.Header.Set(ProxyKeyHeader, "cache-test")
+
+	// First request - cache miss, should create new session
+	server1 := lb.Next(req)
+	if server1 == nil {
+		t.Fatal("expected a server to be selected")
+	}
+
+	// Verify session was created (cache populated)
+	lb.sessionMu.RLock()
+	cachedServer, exists := lb.sessionMap["cache-test"]
+	lb.sessionMu.RUnlock()
+
+	if !exists {
+		t.Fatal("expected session to be created")
+	}
+	if cachedServer != server1 {
+		t.Error("cached server should match returned server")
+	}
+
+	// Second request within timeout - cache hit, should return same server
+	server2 := lb.Next(req)
+	if server2 != server1 {
+		t.Error("expected same server for cache hit")
+	}
+
+	// Wait for session to timeout
+	time.Sleep(150 * time.Millisecond)
+
+	// Third request after timeout - cache miss due to expiry, should trigger inline cleanup
+	server3 := lb.Next(req)
+	if server3 == nil {
+		t.Fatal("expected a server to be selected after timeout")
+	}
+
+	// Verify new session was created after timeout cleanup
+	lb.sessionMu.RLock()
+	newCachedServer, exists := lb.sessionMap["cache-test"]
+	lb.sessionMu.RUnlock()
+
+	if !exists {
+		t.Fatal("expected new session to be created after timeout")
+	}
+	if newCachedServer != server3 {
+		t.Error("new cached server should match returned server")
+	}
+
+	// Verify the old session was cleaned up during the timeout check
+	// (This tests the inline cleanup behavior we just implemented)
+	if server1 == server3 {
+		// If we got the same server, it should be a new session, not the old one
+		// We can't directly test this without more complex session tracking,
+		// but the fact that we created a new session entry confirms the old one was cleaned up
+		t.Logf("Got same server but as new session (expected behavior)")
+	}
+}
+
+func TestStickyLatencyBased_ProxyKeyHeader(t *testing.T) {
+	servers := []*Server{
+		createTestServer("server1", 10*time.Millisecond),
+		createTestServer("server2", 20*time.Millisecond),
+	}
+
+	lb := NewStickyLatencyBased(slog.New(slog.NewTextHandler(os.Stdout, nil)), 5*time.Minute)
+	defer lb.Stop()
+	lb.Update(servers)
+
+	// Test X-PROXY-KEY header
+	req1 := createTestRequest()
+	req1.Header.Set(ProxyKeyHeader, "session-priority")
+
+	server1 := lb.Next(req1)
+	if server1 == nil {
+		t.Fatal("expected a server to be selected")
+	}
+
+	// Same X-PROXY-KEY should stick to same server
+	req2 := createTestRequest()
+	req2.Header.Set(ProxyKeyHeader, "session-priority")
+
+	server2 := lb.Next(req2)
+	if server2.name != server1.name {
+		t.Errorf("expected same server %s, got %s", server1.name, server2.name)
+	}
+}
+
+func TestStickyLatencyBased_ConcurrentAccess(t *testing.T) {
+	servers := []*Server{
+		createTestServer("server1", 10*time.Millisecond),
+		createTestServer("server2", 20*time.Millisecond),
+		createTestServer("server3", 30*time.Millisecond),
+	}
+
+	lb := NewStickyLatencyBased(slog.New(slog.NewTextHandler(os.Stdout, nil)), 5*time.Minute)
+	defer lb.Stop()
+	lb.Update(servers)
+
+	var wg sync.WaitGroup
+	const numGoroutines = 10
+	const requestsPerGoroutine = 20
+
+	// Test concurrent access with multiple sessions
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(goroutineID int) {
+			defer wg.Done()
+
+			sessionID := fmt.Sprintf("session-%d", goroutineID)
+			var lastServer *Server
+
+			for j := 0; j < requestsPerGoroutine; j++ {
+				req := createTestRequest()
+				req.Header.Set(ProxyKeyHeader, sessionID)
+
+				server := lb.Next(req)
+				if server == nil {
+					t.Errorf("goroutine %d: expected a server to be selected", goroutineID)
+					return
+				}
+
+				// After first request, all subsequent requests should go to same server
+				if j > 0 && lastServer != nil && server.name != lastServer.name {
+					t.Errorf("goroutine %d: expected same server %s, got %s",
+						goroutineID, lastServer.name, server.name)
+					return
+				}
+
+				lastServer = server
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestStickyLatencyBased_ServerUpdate(t *testing.T) {
+	initialServers := []*Server{
+		createTestServer("server1", 10*time.Millisecond),
+		createTestServer("server2", 20*time.Millisecond),
+	}
+
+	lb := NewStickyLatencyBased(slog.New(slog.NewTextHandler(os.Stdout, nil)), 5*time.Minute)
+	defer lb.Stop()
+	lb.Update(initialServers)
+
+	// Create session with server1
+	req := createTestRequest()
+	req.Header.Set(ProxyKeyHeader, "session123")
+
+	server1 := lb.Next(req)
+	if server1 == nil {
+		t.Fatal("expected a server to be selected")
+	}
+
+	// Update servers - remove server1, add server3
+	updatedServers := []*Server{
+		createTestServer("server2", 20*time.Millisecond),
+		createTestServer("server3", 15*time.Millisecond),
+	}
+	lb.Update(updatedServers)
+
+	// Request with same session should now go to a different server since server1 is gone
+	server2 := lb.Next(req)
+	if server2 == nil {
+		t.Fatal("expected a server to be selected")
+	}
+
+	// Verify session mapping still exists and points to a valid server
+	lb.sessionMu.RLock()
+	server, exists := lb.sessionMap["session123"]
+	lb.sessionMu.RUnlock()
+
+	if exists && server == nil {
+		t.Error("session exists but points to nil server")
+	}
+}
+
+// Helper functions for tests
+
+func createTestServer(name string, latency time.Duration) *Server {
+	testURL, _ := url.Parse("http://example.com")
+	return &Server{
+		name:         name,
+		Url:          testURL,
+		pings:        avg.Moving(1),
+		successes:    nil,
+		failures:     nil,
+		requestCount: atomic.Int64{},
+		log:          nil,
+		node: seed.Node{
+			Status: seed.Status{
+				Reachable:     true,
+				CatchingUp:    false,
+				IsLatestBlock: true,
+				Latency:       latency,
+			},
+		},
+	}
+}
+
+func createTestRequest() *http.Request {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	return req
 }

--- a/internal/proxy/balancer_test.go
+++ b/internal/proxy/balancer_test.go
@@ -508,6 +508,10 @@ func TestStickyLatencyBased_ServerUpdate(t *testing.T) {
 		t.Fatal("expected a server to be selected")
 	}
 
+	if server2.name == server1.name {
+		t.Fatalf("expected a different server after update; still got %s", server2.name)
+	}
+
 	// Verify session mapping still exists and points to a valid server
 	lb.sessionMu.RLock()
 	server, exists := lb.sessionMap["session123"]

--- a/internal/proxy/balancer_test.go
+++ b/internal/proxy/balancer_test.go
@@ -495,6 +495,14 @@ func TestStickyLatencyBased_ServerUpdate(t *testing.T) {
 		t.Fatal("expected a server to be selected")
 	}
 
+	// Verify session was created
+	lb.sessionMu.RLock()
+	originalServer, sessionExists := lb.sessionMap["session123"]
+	lb.sessionMu.RUnlock()
+	if !sessionExists {
+		t.Fatal("expected session to be created")
+	}
+
 	// Update servers - remove server1, add server3
 	updatedServers := []*Server{
 		createTestServer("server2", 20*time.Millisecond),
@@ -502,23 +510,52 @@ func TestStickyLatencyBased_ServerUpdate(t *testing.T) {
 	}
 	lb.Update(updatedServers)
 
-	// Request with same session should now go to a different server since server1 is gone
-	server2 := lb.NextServer(req)
-	if server2 == nil {
-		t.Fatal("expected a server to be selected")
+	// If the original server was removed, the session should be cleaned up
+	serverWasRemoved := true
+	for _, s := range updatedServers {
+		if s.name == originalServer.name {
+			serverWasRemoved = false
+			break
+		}
 	}
 
-	if server2.name == server1.name {
-		t.Fatalf("expected a different server after update; still got %s", server2.name)
-	}
+	if serverWasRemoved {
+		// Session should have been removed
+		lb.sessionMu.RLock()
+		_, sessionStillExists := lb.sessionMap["session123"]
+		lb.sessionMu.RUnlock()
+		if sessionStillExists {
+			t.Error("expected session to be removed when server was removed")
+		}
 
-	// Verify session mapping still exists and points to a valid server
-	lb.sessionMu.RLock()
-	server, exists := lb.sessionMap["session123"]
-	lb.sessionMu.RUnlock()
+		// Request with same session should create a new session with an available server
+		server2 := lb.NextServer(req)
+		if server2 == nil {
+			t.Fatal("expected a server to be selected")
+		}
 
-	if exists && server == nil {
-		t.Error("session exists but points to nil server")
+		// Verify the selected server is one of the available servers
+		serverIsValid := false
+		for _, s := range updatedServers {
+			if s.name == server2.name {
+				serverIsValid = true
+				break
+			}
+		}
+		if !serverIsValid {
+			t.Fatalf("selected server %s is not in the updated server list", server2.name)
+		}
+
+		// Verify new session was created
+		lb.sessionMu.RLock()
+		newServer, newSessionExists := lb.sessionMap["session123"]
+		lb.sessionMu.RUnlock()
+		if !newSessionExists {
+			t.Error("expected new session to be created")
+		}
+		if newServer == nil {
+			t.Error("new session points to nil server")
+		}
 	}
 }
 

--- a/internal/proxy/balancer_test.go
+++ b/internal/proxy/balancer_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/akash-network/rpc-proxy/internal/seed"
 )
 
-func TestRoundRobin_Next(t *testing.T) {
+func TestRoundRobin_NextServer(t *testing.T) {
 	servers := []*Server{
 		{
 			name:         "a",
@@ -67,7 +67,7 @@ func TestRoundRobin_Next(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < n; j++ {
 				t.Logf("goroutine %d: ", id)
-				lb.Next(nil)
+				lb.NextServer(nil)
 			}
 		}(i)
 	}
@@ -79,7 +79,7 @@ func TestRoundRobin_Next(t *testing.T) {
 	}
 }
 
-func TestLatencyBased_Next(t *testing.T) {
+func TestLatencyBased_NextServer(t *testing.T) {
 	servers := []*Server{
 		{
 			name:         "a",
@@ -142,7 +142,7 @@ func TestLatencyBased_Next(t *testing.T) {
 		go func(id int) {
 			for j := 0; j < n; j++ {
 				t.Logf("goroutine %d: ", id)
-				queue <- lb.Next(nil)
+				queue <- lb.NextServer(nil)
 			}
 			wg.Done()
 		}(i)
@@ -190,7 +190,7 @@ func TestStickyLatencyBased_SessionAffinity(t *testing.T) {
 	req1.Header.Set(ProxyKeyHeader, "session123")
 
 	// First request should select a server (using weighted random selection)
-	server1 := lb.Next(req1)
+	server1 := lb.NextServer(req1)
 	if server1 == nil {
 		t.Fatal("expected a server to be selected")
 	}
@@ -199,7 +199,7 @@ func TestStickyLatencyBased_SessionAffinity(t *testing.T) {
 	// Second request with same session ID should go to same server
 	req2 := createTestRequest()
 	req2.Header.Set(ProxyKeyHeader, "session123")
-	server2 := lb.Next(req2)
+	server2 := lb.NextServer(req2)
 
 	if server2.name != server1.name {
 		t.Errorf("expected same server %s, got %s", server1.name, server2.name)
@@ -208,7 +208,7 @@ func TestStickyLatencyBased_SessionAffinity(t *testing.T) {
 	// Different session ID should potentially select different server (but likely same due to latency)
 	req3 := createTestRequest()
 	req3.Header.Set(ProxyKeyHeader, "session456")
-	server3 := lb.Next(req3)
+	server3 := lb.NextServer(req3)
 
 	if server3 == nil {
 		t.Fatal("expected a server to be selected")
@@ -230,7 +230,7 @@ func TestStickyLatencyBased_NoProxyKey(t *testing.T) {
 	req1 := createTestRequest()
 	// No X-PROXY-KEY header set
 
-	server1 := lb.Next(req1)
+	server1 := lb.NextServer(req1)
 	if server1 == nil {
 		t.Fatal("expected a server to be selected")
 	}
@@ -241,7 +241,7 @@ func TestStickyLatencyBased_NoProxyKey(t *testing.T) {
 
 	// Second request without X-PROXY-KEY should also use latency-based selection
 	req2 := createTestRequest()
-	server2 := lb.Next(req2)
+	server2 := lb.NextServer(req2)
 
 	if server2 == nil {
 		t.Fatal("expected a server to be selected")
@@ -265,7 +265,7 @@ func TestStickyLatencyBased_SessionPersistence(t *testing.T) {
 	req1 := createTestRequest()
 	req1.Header.Set(ProxyKeyHeader, "session123")
 
-	server1 := lb.Next(req1)
+	server1 := lb.NextServer(req1)
 	if server1 == nil {
 		t.Fatal("expected a server to be selected")
 	}
@@ -273,7 +273,7 @@ func TestStickyLatencyBased_SessionPersistence(t *testing.T) {
 	// Second request with same session should go to same server
 	req2 := createTestRequest()
 	req2.Header.Set(ProxyKeyHeader, "session123")
-	server2 := lb.Next(req2)
+	server2 := lb.NextServer(req2)
 
 	if server2 == nil {
 		t.Fatal("expected a server to be selected")
@@ -304,7 +304,7 @@ func TestStickyLatencyBased_SessionTimeout(t *testing.T) {
 	req1 := createTestRequest()
 	req1.Header.Set(ProxyKeyHeader, "session123")
 
-	server1 := lb.Next(req1)
+	server1 := lb.NextServer(req1)
 	if server1 == nil {
 		t.Fatal("expected a server to be selected")
 	}
@@ -344,7 +344,7 @@ func TestStickyLatencyBased_CacheHitMiss(t *testing.T) {
 	req.Header.Set(ProxyKeyHeader, "cache-test")
 
 	// First request - cache miss, should create new session
-	server1 := lb.Next(req)
+	server1 := lb.NextServer(req)
 	if server1 == nil {
 		t.Fatal("expected a server to be selected")
 	}
@@ -362,7 +362,7 @@ func TestStickyLatencyBased_CacheHitMiss(t *testing.T) {
 	}
 
 	// Second request within timeout - cache hit, should return same server
-	server2 := lb.Next(req)
+	server2 := lb.NextServer(req)
 	if server2 != server1 {
 		t.Error("expected same server for cache hit")
 	}
@@ -371,7 +371,7 @@ func TestStickyLatencyBased_CacheHitMiss(t *testing.T) {
 	time.Sleep(150 * time.Millisecond)
 
 	// Third request after timeout - cache miss due to expiry, should trigger inline cleanup
-	server3 := lb.Next(req)
+	server3 := lb.NextServer(req)
 	if server3 == nil {
 		t.Fatal("expected a server to be selected after timeout")
 	}
@@ -412,7 +412,7 @@ func TestStickyLatencyBased_ProxyKeyHeader(t *testing.T) {
 	req1 := createTestRequest()
 	req1.Header.Set(ProxyKeyHeader, "session-priority")
 
-	server1 := lb.Next(req1)
+	server1 := lb.NextServer(req1)
 	if server1 == nil {
 		t.Fatal("expected a server to be selected")
 	}
@@ -421,7 +421,7 @@ func TestStickyLatencyBased_ProxyKeyHeader(t *testing.T) {
 	req2 := createTestRequest()
 	req2.Header.Set(ProxyKeyHeader, "session-priority")
 
-	server2 := lb.Next(req2)
+	server2 := lb.NextServer(req2)
 	if server2.name != server1.name {
 		t.Errorf("expected same server %s, got %s", server1.name, server2.name)
 	}
@@ -455,7 +455,7 @@ func TestStickyLatencyBased_ConcurrentAccess(t *testing.T) {
 				req := createTestRequest()
 				req.Header.Set(ProxyKeyHeader, sessionID)
 
-				server := lb.Next(req)
+				server := lb.NextServer(req)
 				if server == nil {
 					t.Errorf("goroutine %d: expected a server to be selected", goroutineID)
 					return
@@ -490,7 +490,7 @@ func TestStickyLatencyBased_ServerUpdate(t *testing.T) {
 	req := createTestRequest()
 	req.Header.Set(ProxyKeyHeader, "session123")
 
-	server1 := lb.Next(req)
+	server1 := lb.NextServer(req)
 	if server1 == nil {
 		t.Fatal("expected a server to be selected")
 	}
@@ -503,7 +503,7 @@ func TestStickyLatencyBased_ServerUpdate(t *testing.T) {
 	lb.Update(updatedServers)
 
 	// Request with same session should now go to a different server since server1 is gone
-	server2 := lb.Next(req)
+	server2 := lb.NextServer(req)
 	if server2 == nil {
 		t.Fatal("expected a server to be selected")
 	}

--- a/internal/proxy/grpc.go
+++ b/internal/proxy/grpc.go
@@ -44,7 +44,7 @@ func (p *GRPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if srv := p.lb.Next(); srv != nil {
+	if srv := p.lb.Next(r); srv != nil {
 
 		// Create the reverse proxy
 		proxy := httputil.ReverseProxy{

--- a/internal/proxy/grpc.go
+++ b/internal/proxy/grpc.go
@@ -44,7 +44,7 @@ func (p *GRPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if srv := p.lb.Next(r); srv != nil {
+	if srv := p.lb.NextServer(r); srv != nil {
 
 		// Create the reverse proxy
 		proxy := httputil.ReverseProxy{

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -50,7 +50,6 @@ func TestRPCProxy(t *testing.T) {
 
 	stats := proxy.Stats()
 	require.Len(t, stats, 3)
-
 }
 
 func TestRestProxy(t *testing.T) {
@@ -319,6 +318,6 @@ type MockLoadBalancer struct{}
 
 func (m *MockLoadBalancer) Update(servers []*Server) {}
 
-func (m *MockLoadBalancer) Next(*http.Request) *Server {
+func (m *MockLoadBalancer) NextServer(*http.Request) *Server {
 	return nil
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -319,6 +319,6 @@ type MockLoadBalancer struct{}
 
 func (m *MockLoadBalancer) Update(servers []*Server) {}
 
-func (m *MockLoadBalancer) Next() *Server {
+func (m *MockLoadBalancer) Next(*http.Request) *Server {
 	return nil
 }

--- a/internal/proxy/rest.go
+++ b/internal/proxy/rest.go
@@ -47,7 +47,7 @@ func (p *RestProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/rest")
-	if srv := p.lb.Next(r); srv != nil {
+	if srv := p.lb.NextServer(r); srv != nil {
 		proxy := newRedirectFollowingReverseProxy(srv, p.log, "rest")
 		proxy.ServeHTTP(w, r)
 		metrics.IncrementRequestCount("rest", srv.Url.String())

--- a/internal/proxy/rest.go
+++ b/internal/proxy/rest.go
@@ -47,7 +47,7 @@ func (p *RestProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/rest")
-	if srv := p.lb.Next(); srv != nil {
+	if srv := p.lb.Next(r); srv != nil {
 		proxy := newRedirectFollowingReverseProxy(srv, p.log, "rest")
 		proxy.ServeHTTP(w, r)
 		metrics.IncrementRequestCount("rest", srv.Url.String())

--- a/internal/proxy/rpc.go
+++ b/internal/proxy/rpc.go
@@ -47,7 +47,7 @@ func (p *RPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/rpc")
-	if srv := p.lb.Next(); srv != nil {
+	if srv := p.lb.Next(r); srv != nil {
 		proxy := newRedirectFollowingReverseProxy(srv, p.log, "rpc")
 		proxy.ServeHTTP(w, r)
 		metrics.IncrementRequestCount("rpc", srv.Url.String())

--- a/internal/proxy/rpc.go
+++ b/internal/proxy/rpc.go
@@ -47,7 +47,7 @@ func (p *RPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/rpc")
-	if srv := p.lb.Next(r); srv != nil {
+	if srv := p.lb.NextServer(r); srv != nil {
 		proxy := newRedirectFollowingReverseProxy(srv, p.log, "rpc")
 		proxy.ServeHTTP(w, r)
 		metrics.IncrementRequestCount("rpc", srv.Url.String())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session affinity across RPC/REST/gRPC using a sticky latency policy for more consistent routing.
  * Support for client-provided session keys via the X-PROXY-KEY header.
  * Short sticky latency window (short-term stickiness) to stabilize backend selection.

* **Bug Fixes**
  * Fixed REST routing that could report “no servers available” after a successful selection.

* **Tests**
  * Expanded coverage for session affinity, TTL/cleanup, concurrency, cache semantics, and server updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->